### PR TITLE
✨ Chip 컴포넌트 추가

### DIFF
--- a/src/components/common/chip/Chip.module.css
+++ b/src/components/common/chip/Chip.module.css
@@ -1,0 +1,75 @@
+.status,
+.status-option {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: fit-content;
+  padding: 4px 10px;
+  border-radius: 16px;
+  background-color: var(--violet-bright);
+  color: var(--violet);
+}
+
+.status {
+  font-size: 12px;
+  line-height: 18px;
+}
+
+.status-option {
+  font-size: 14px;
+  line-height: 24px;
+}
+
+.tag {
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 14px;
+  line-height: 24px;
+}
+
+.tag.orange {
+  background-color: #f9eee3;
+  color: #d58d49;
+}
+
+.tag.green {
+  background-color: #e7f7db;
+  color: #86d549;
+}
+
+.tag.pink {
+  background-color: #f7dbf0;
+  color: #d549b6;
+}
+
+.tag.blue {
+  background-color: #dbe6f7;
+  color: #4981d5;
+}
+
+.dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  margin-right: 6px;
+  border-radius: 50%;
+  background-color: var(--violet);
+}
+
+@media screen and (max-width: 743px) {
+  .status,
+  .status-option {
+    padding: 4px 8px;
+  }
+
+  .status-option {
+    font-size: 12px;
+    line-height: 18px;
+  }
+
+  .tag {
+    padding: 4px 6px;
+    font-size: 12px;
+    line-height: 18px;
+  }
+}

--- a/src/components/common/chip/Chip.tsx
+++ b/src/components/common/chip/Chip.tsx
@@ -1,0 +1,38 @@
+import clsx from 'clsx';
+import { ChipProps } from '@/type/chip';
+import { PropsWithChildren } from 'react';
+import styles from './Chip.module.css';
+import getTagColor from './helper';
+
+/**
+ * Chip 컴포넌트
+ * - 다양한 유형의 Chip을 렌더링하는 공통 컴포넌트.
+ * - chipType(['tag', 'status', 'status-option'])에 따라 스타일과 Dot 렌더링 여부를 결정합니다.
+ *
+ * @param {string} props.chipType - Chip의 타입을 지정
+ * @param {React.ReactNode} props.children - Chip 내부에 렌더링할 내용
+ * @returns {JSX.Element} Chip 컴포넌트의
+ */
+function Chip({ children, chipType }: PropsWithChildren<ChipProps>) {
+  /**
+   * renderDot: status인 타입인 경우 점을 렌더링
+   * - 조건: chipType.startsWith('status') -> status | status-option
+   * @returns {JSX.Element} - 점 span 태그
+   */
+  const renderDot = () =>
+    chipType.startsWith('status') && <span className={styles.dot} />;
+
+  const className = clsx(
+    styles[chipType],
+    chipType === 'tag' && getTagColor(styles),
+  );
+
+  return (
+    <span className={className}>
+      {renderDot()}
+      {children}
+    </span>
+  );
+}
+
+export default Chip;

--- a/src/components/common/chip/helper.ts
+++ b/src/components/common/chip/helper.ts
@@ -1,0 +1,16 @@
+import { bgTag } from '@/type/chip';
+
+/**
+ * 랜덤한 tag 클래스를 반환하는 함수
+ * - bgTag 배열에서 랜덤하게 선택
+ *
+ * @param {Record<string, string>} styles - 스타일 객체
+ * @returns {string} 랜덤 배경색 클래스 이름
+ */
+export const getTagColor = (styles: Record<string, string>): string => {
+  if (!bgTag || bgTag.length === 0) return '';
+  const idx = Math.floor(Math.random() * bgTag.length);
+  return styles[bgTag[idx]];
+};
+
+export default getTagColor;

--- a/src/type/chip.ts
+++ b/src/type/chip.ts
@@ -1,0 +1,10 @@
+import { ReactNode } from 'react';
+
+type ChipType = 'tag' | 'status' | 'status-option';
+
+export interface ChipProps {
+  children: ReactNode;
+  chipType: ChipType;
+}
+
+export const bgTag = ['orange', 'green', 'pink', 'blue'];


### PR DESCRIPTION
### 이슈 번호

close #44 

### 변경 사항 요약

공통 컴포넌트 Chip 추가했습니다.

### 사용 방법
![image](https://github.com/user-attachments/assets/f2a8eca5-da8d-43f5-9f41-3eb8d543a7f9)

```tsx
<Chip chipType="status">To Do</Chip>
<Chip chipType="status-option">To Do</Chip>
<Chip chipType="tag">프로젝트</Chip>
<Chip chipType="tag">일반</Chip>
<Chip chipType="tag">백엔드</Chip>
<Chip chipType="tag">상</Chip>
```

### 테스트 결과
![image](https://github.com/user-attachments/assets/2501bb32-473b-46af-88c4-8466904f7e42)

### 리뷰포인트
Chip 컴포넌트를 tag 타입으로 사용할 때 임의로 ['orange', 'green', 'blue', 'pink'] 중 랜덤으로 컬러 지정하도록 설정했습니다.
논의 후에 방향 결정되면 수정하도록 하겠습니다. 