### PR TITLE
#52 공통 모달 오버레이  모달가입완료 비밀번호 불일치 중복 이메일

### DIFF
--- a/src/components/common/modal/auth/AuthModal.module.css
+++ b/src/components/common/modal/auth/AuthModal.module.css
@@ -1,0 +1,23 @@
+.authModal_section {
+  border-radius: 16px;
+  background-color: #fff;
+  padding: 40px 64px;
+}
+
+.message {
+  font-size: 20px;
+  font-weight: 500;
+  color: var(--black-medium);
+  margin-bottom: 32px;
+}
+
+@media screen and (max-width: 743px) {
+  .authModal_section {
+    padding: 32px 40px;
+  }
+
+  .message {
+    font-size: 16px;
+    margin-bottom: 32px;
+  }
+}

--- a/src/components/common/modal/auth/AuthModal.module.css
+++ b/src/components/common/modal/auth/AuthModal.module.css
@@ -1,6 +1,9 @@
 .authModal_section {
   border-radius: 16px;
   background-color: #fff;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   padding: 40px 64px;
 }
 

--- a/src/components/common/modal/auth/AuthModal.tsx
+++ b/src/components/common/modal/auth/AuthModal.tsx
@@ -1,12 +1,12 @@
 import CDSButton from '../../button/CDSButton';
 import styles from './AuthModal.module.css';
 
-function AuthModal({ message, handleClick }) {
+function AuthModal({ message, handleCancelClick }) {
   return (
     <div className={styles.authModal_section}>
       <p className={styles.message}>{message}</p>
 
-      <CDSButton btnType="modal_single" onClick={handleClick}>
+      <CDSButton btnType="modal_single" onClick={handleCancelClick}>
         확인
       </CDSButton>
     </div>

--- a/src/components/common/modal/auth/AuthModal.tsx
+++ b/src/components/common/modal/auth/AuthModal.tsx
@@ -1,0 +1,16 @@
+import CDSButton from '../../button/CDSButton';
+import styles from './AuthModal.module.css';
+
+function AuthModal({ message, handleClick }) {
+  return (
+    <div className={styles.authModal_section}>
+      <p className={styles.message}>{message}</p>
+
+      <CDSButton btnType="modal_single" onClick={handleClick}>
+        확인
+      </CDSButton>
+    </div>
+  );
+}
+
+export default AuthModal;

--- a/src/components/common/modal/auth/Test_AuthModal.tsx
+++ b/src/components/common/modal/auth/Test_AuthModal.tsx
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+import AuthModal from './AuthModal';
+import OverlayContainer from '../overlay-container/OverlayContainer';
+
+function TestAuthModal() {
+  const [Modal, setModal] = useState(false);
+  const onClick = () => {
+    setModal(true);
+  };
+
+  const handleClick = () => {
+    setModal(false);
+  };
+
+  return (
+    <>
+      <button onClick={onClick}>모달 열기</button>
+      {Modal && (
+        <OverlayContainer>
+          <AuthModal
+            message={'비밀번호가 일치하지 않습니다.'}
+            handleClick={handleClick}
+          />
+        </OverlayContainer>
+      )}
+    </>
+  );
+}
+
+export default TestAuthModal;

--- a/src/components/common/modal/auth/Test_AuthModal.tsx
+++ b/src/components/common/modal/auth/Test_AuthModal.tsx
@@ -8,18 +8,20 @@ function TestAuthModal() {
     setModal(true);
   };
 
-  const handleClick = () => {
+  const handleCancelClick = () => {
     setModal(false);
   };
 
   return (
     <>
-      <button onClick={onClick}>모달 열기</button>
+      <button onClick={onClick}>
+        가입완료 + 비밀번호 불일치(로그인, 마이페이지) + 중복 이메일 모달
+      </button>
       {Modal && (
         <OverlayContainer>
           <AuthModal
             message={'비밀번호가 일치하지 않습니다.'}
-            handleClick={handleClick}
+            handleCancelClick={handleCancelClick}
           />
         </OverlayContainer>
       )}

--- a/src/components/common/modal/delete-cards/DeleteCardsModal.module.css
+++ b/src/components/common/modal/delete-cards/DeleteCardsModal.module.css
@@ -1,0 +1,26 @@
+.deleteCardsModal_section {
+  border-radius: 16px;
+  background-color: #fff;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 24px;
+}
+
+.message {
+  font-size: 20px;
+  font-weight: 500;
+  color: var(--black-medium);
+  margin-bottom: 32px;
+}
+
+@media screen and (max-width: 743px) {
+  .deleteCardsModal_section {
+    padding: 24px 16px;
+  }
+
+  .message {
+    font-size: 16px;
+    margin-bottom: 32px;
+  }
+}

--- a/src/components/common/modal/delete-cards/DeleteCardsModal.tsx
+++ b/src/components/common/modal/delete-cards/DeleteCardsModal.tsx
@@ -1,0 +1,22 @@
+import CDSButton from '../../button/CDSButton';
+import styles from './DeleteCardsModal.module.css';
+
+function DeleteCardsModal({ message, handleCancelClick, handleDeleteClick }) {
+  return (
+    <div className={styles.deleteCardsModal_section}>
+      <p className={styles.message}>{message}</p>
+
+      <div>
+        <CDSButton btnType="modal" onClick={handleCancelClick}>
+          취소
+        </CDSButton>
+        <span style={{ margin: '0 5px' }} />
+        <CDSButton btnType="modal_colored" onClick={handleDeleteClick}>
+          삭제
+        </CDSButton>
+      </div>
+    </div>
+  );
+}
+
+export default DeleteCardsModal;

--- a/src/components/common/modal/delete-cards/Test_DeleteCardsModal.tsx
+++ b/src/components/common/modal/delete-cards/Test_DeleteCardsModal.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+import OverlayContainer from '../overlay-container/OverlayContainer';
+import DeleteCardsModal from './DeleteCardsModal';
+
+function TestDeleteCardsModal() {
+  const [Modal, setModal] = useState(false);
+  const onClick = () => {
+    setModal(true);
+  };
+
+  const handleCancelClick = () => {
+    setModal(false);
+  };
+
+  const handleDeleteClick = () => {
+    console.log('Delete');
+  };
+
+  return (
+    <>
+      <button onClick={onClick}>카드 삭제 모달</button>
+      {Modal && (
+        <OverlayContainer>
+          <DeleteCardsModal
+            message={'컬럼의 모든 카드가 삭제됩니다.'}
+            handleCancelClick={handleCancelClick}
+            handleDeleteClick={handleDeleteClick}
+          />
+        </OverlayContainer>
+      )}
+    </>
+  );
+}
+
+export default TestDeleteCardsModal;

--- a/src/components/common/modal/overlay-container/OverlayContainer.module.css
+++ b/src/components/common/modal/overlay-container/OverlayContainer.module.css
@@ -1,0 +1,11 @@
+.OverlayContainer {
+  background-color: rgba(0, 0, 0, 0.5);
+  width: 100%;
+  height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: fixed;
+  top: 0;
+  left: 0;
+}

--- a/src/components/common/modal/overlay-container/OverlayContainer.tsx
+++ b/src/components/common/modal/overlay-container/OverlayContainer.tsx
@@ -1,0 +1,7 @@
+import styles from './OverlayContainer.module.css';
+
+function OverlayContainer({ children }) {
+  return <div className={styles.OverlayContainer}>{children}</div>;
+}
+
+export default OverlayContainer;


### PR DESCRIPTION
### 이슈 번호

close #52 

### 변경 사항 요약

- 공통 모달 오버레이 추가했습니다.
- 가입완료 + 비밀번호 불일치(로그인, 마이페이지) + 중복 이메일 추가했습니다.
- 칼럼 관리 모달 -> 삭제 -> 칼럼의 모든 카드 삭제 추가했습니다.

### 테스트 결과

## PC
<img width="855" alt="스크린샷 2024-12-14 16 30 52" src="https://github.com/user-attachments/assets/958e65df-ecbd-44fa-b464-8d6bc5b03761" />

## Mobile
<img width="331" alt="스크린샷 2024-12-14 16 31 04" src="https://github.com/user-attachments/assets/0deaea22-9675-4987-8dc7-acb575862005" />

## PC
<img width="728" alt="스크린샷 2024-12-14 16 31 22" src="https://github.com/user-attachments/assets/9a394df0-7640-4445-a1d8-8c5216085f08" />

## Mobile
<img width="339" alt="스크린샷 2024-12-14 16 31 29" src="https://github.com/user-attachments/assets/d2cbbd7d-0483-4322-865c-4d681c13663e" />

Tablet의 경우 PC와 동일하여 추가하지 않았습니다.

### 리뷰포인트

- 공통으로 사용할 오버레이 작업했는데 이렇게 하면 되는 건지 모르겠지만 우선 이렇게 작업했습니다.. 혹시 문제 있다면 추가 수정 바로 해드리도록 할테니 말씀 부탁드릴게요.
- 오버레이 안의 모달 테두리? 부분도 공통으로 사용할 수 있게 만들까 했지만 모달별로 radius, padding 등 다양한 케이스가 있어서 이 부분은 담당자별로 작업하시는게 좋을 것 같아 추가 작업하지 않았습니다.
- 모달별 테스트 파일 import하시면 제가 임의로 만들어둔 버튼 클릭해서 확인할 수 있습니다. 참고 부탁드립니다.