### PR TITLE
#77 대시보드 배지 컬러 수정

### DIFF
--- a/src/components/common/button/CDSButton.tsx
+++ b/src/components/common/button/CDSButton.tsx
@@ -46,7 +46,9 @@ function CDSButton({
    */
   const renderBadge = () =>
     btnType === 'dashboard_card' &&
-    badge && <span className={clsx(styles.badge, styles[badge])} />;
+    badge && (
+      <span className={clsx(styles.badge)} style={{ backgroundColor: badge }} />
+    );
 
   const renderArrowIcon = () => {
     if (btnType === 'pagination_prev')

--- a/src/pages/test_button.tsx
+++ b/src/pages/test_button.tsx
@@ -68,23 +68,23 @@ function ButtonPage() {
         대시보드 삭제하기
       </CDSButton>
       <br />
-      <CDSButton btnType="dashboard_card" badge="green" onClick={handleClick}>
+      <CDSButton btnType="dashboard_card" badge="#7ac555" onClick={handleClick}>
         비브리지
       </CDSButton>
       <br />
-      <CDSButton btnType="dashboard_card" badge="purple" onClick={handleClick}>
+      <CDSButton btnType="dashboard_card" badge="#760dde" onClick={handleClick}>
         비브리지
       </CDSButton>
       <br />
-      <CDSButton btnType="dashboard_card" badge="orange" onClick={handleClick}>
+      <CDSButton btnType="dashboard_card" badge="#ffa500" onClick={handleClick}>
         비브리지
       </CDSButton>
       <br />
-      <CDSButton btnType="dashboard_card" badge="blue" onClick={handleClick}>
+      <CDSButton btnType="dashboard_card" badge="#76a5ea" onClick={handleClick}>
         비브리지
       </CDSButton>
       <br />
-      <CDSButton btnType="dashboard_card" badge="pink" onClick={handleClick}>
+      <CDSButton btnType="dashboard_card" badge="#e876ea" onClick={handleClick}>
         비브리지
       </CDSButton>
       <br />

--- a/src/pages/test_button.tsx
+++ b/src/pages/test_button.tsx
@@ -90,7 +90,7 @@ function ButtonPage() {
       <br />
       <CDSButton
         btnType="dashboard_card"
-        badge="green"
+        badge="#7ac555"
         owner
         onClick={handleClick}
       >

--- a/src/type/button.ts
+++ b/src/type/button.ts
@@ -2,7 +2,12 @@ import { ButtonHTMLAttributes, ReactNode } from 'react';
 
 // BadgeColor: 배지 색상 타입.
 // 허용되는 색상: 'green', 'purple', 'orange', 'blue', 'pink'
-export type BadgeColor = 'green' | 'purple' | 'orange' | 'blue' | 'pink';
+export type BadgeColor =
+  | '#7ac555'
+  | '#760dde'
+  | '#ffa500'
+  | '#76a5ea'
+  | '#e876ea';
 
 // 버튼의 타입과 관련된 클래스 리스트.
 export const types = {


### PR DESCRIPTION
### 이슈 번호

close #77 

### 변경 사항 요약

배지 컬러 HexCode 사용하도록 수정했습니다. 

### 테스트 결과
사용법
![image](https://github.com/user-attachments/assets/5aff8c21-fa31-4f99-b521-162798a0c324)

사용 가능 컬러(피그마 기준 5개로 제한)
![image](https://github.com/user-attachments/assets/ce77ce20-9e6a-41c5-a9e7-c8edecef465e)


![image](https://github.com/user-attachments/assets/4e11ce60-2a22-4c29-b9ea-516b4effd9f8)
