### PR TITLE
Navbar 마이페이지, 로그아웃 기능 추가 및 모달 오버레이 전체적으로 수정

### DIFF
--- a/src/components/common/button/NavButton.module.css
+++ b/src/components/common/button/NavButton.module.css
@@ -6,7 +6,7 @@
 
   border: 1px solid var(--gray-medium);
   border-radius: 8px;
-  background-color: none;
+  background: none;
   padding: 0 16px;
 
   font-size: 16px;
@@ -30,12 +30,12 @@
   display: inline-block;
   margin-right: 8px;
 
-  background-image: url('/ic/ic_setting.svg') no-repeat;
+  background: url('/ic/ic_setting.svg') no-repeat;
   background-size: 100%;
 }
 
 .button.invite::before {
-  background-image: url('/ic/ic_plus.svg') no-repeat;
+  background: url('/ic/ic_plus.svg') no-repeat;
   background-size: 100%;
 }
 

--- a/src/components/common/modal/auth/AuthModal.tsx
+++ b/src/components/common/modal/auth/AuthModal.tsx
@@ -1,15 +1,18 @@
 import CDSButton from '../../button/CDSButton';
+import OverlayContainer from '../overlay-container/OverlayContainer';
 import styles from './AuthModal.module.css';
 
 function AuthModal({ message, handleCancelClick }) {
   return (
-    <div className={styles['authModal-section']}>
-      <p className={styles.message}>{message}</p>
+    <OverlayContainer>
+      <div className={styles['authModal-section']}>
+        <p className={styles.message}>{message}</p>
 
-      <CDSButton btnType="modal_single" onClick={handleCancelClick}>
-        확인
-      </CDSButton>
-    </div>
+        <CDSButton btnType="modal_single" onClick={handleCancelClick}>
+          확인
+        </CDSButton>
+      </div>
+    </OverlayContainer>
   );
 }
 

--- a/src/components/common/modal/auth/Test_AuthModal.tsx
+++ b/src/components/common/modal/auth/Test_AuthModal.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import AuthModal from './AuthModal';
-import OverlayContainer from '../overlay-container/OverlayContainer';
 
 function TestAuthModal() {
   const [Modal, setModal] = useState(false);
@@ -18,12 +17,10 @@ function TestAuthModal() {
         가입완료 + 비밀번호 불일치(로그인, 마이페이지) + 중복 이메일 모달
       </button>
       {Modal && (
-        <OverlayContainer>
-          <AuthModal
-            message={'비밀번호가 일치하지 않습니다.'}
-            handleCancelClick={handleCancelClick}
-          />
-        </OverlayContainer>
+        <AuthModal
+          message={'비밀번호가 일치하지 않습니다.'}
+          handleCancelClick={handleCancelClick}
+        />
       )}
     </>
   );

--- a/src/components/common/modal/delete-cards/DeleteCardsModal.tsx
+++ b/src/components/common/modal/delete-cards/DeleteCardsModal.tsx
@@ -1,21 +1,24 @@
 import CDSButton from '../../button/CDSButton';
+import OverlayContainer from '../overlay-container/OverlayContainer';
 import styles from './DeleteCardsModal.module.css';
 
 function DeleteCardsModal({ message, handleCancelClick, handleDeleteClick }) {
   return (
-    <div className={styles.deleteCardsModal_section}>
-      <p className={styles.message}>{message}</p>
+    <OverlayContainer>
+      <div className={styles.deleteCardsModal_section}>
+        <p className={styles.message}>{message}</p>
 
-      <div>
-        <CDSButton btnType="modal" onClick={handleCancelClick}>
-          취소
-        </CDSButton>
-        <span style={{ margin: '0 5px' }} />
-        <CDSButton btnType="modal_colored" onClick={handleDeleteClick}>
-          삭제
-        </CDSButton>
+        <div>
+          <CDSButton btnType="modal" onClick={handleCancelClick}>
+            취소
+          </CDSButton>
+          <span style={{ margin: '0 5px' }} />
+          <CDSButton btnType="modal_colored" onClick={handleDeleteClick}>
+            삭제
+          </CDSButton>
+        </div>
       </div>
-    </div>
+    </OverlayContainer>
   );
 }
 

--- a/src/components/common/modal/delete-cards/Test_DeleteCardsModal.tsx
+++ b/src/components/common/modal/delete-cards/Test_DeleteCardsModal.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import OverlayContainer from '../overlay-container/OverlayContainer';
 import DeleteCardsModal from './DeleteCardsModal';
 
 function TestDeleteCardsModal() {
@@ -20,13 +19,11 @@ function TestDeleteCardsModal() {
     <>
       <button onClick={onClick}>카드 삭제 모달</button>
       {Modal && (
-        <OverlayContainer>
-          <DeleteCardsModal
-            message={'컬럼의 모든 카드가 삭제됩니다.'}
-            handleCancelClick={handleCancelClick}
-            handleDeleteClick={handleDeleteClick}
-          />
-        </OverlayContainer>
+        <DeleteCardsModal
+          message={'컬럼의 모든 카드가 삭제됩니다.'}
+          handleCancelClick={handleCancelClick}
+          handleDeleteClick={handleDeleteClick}
+        />
       )}
     </>
   );

--- a/src/components/common/modal/general/GeneralModal.module.css
+++ b/src/components/common/modal/general/GeneralModal.module.css
@@ -1,52 +1,60 @@
-.modal_container {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%; 
-  height: 100%;
-  background: rgba(0, 0, 0, 0.5);
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
+.modal-section {
+  position: relative;
 
-.modal_section {
   display: flex;
   flex-direction: column;
-  background: white;
-  padding: 20px;
-  border-radius: 5px;
-  position: relative;
   gap: 24px;
+  padding: 24px;
+
+  background: var(--white);
+  border-radius: 8px;
 }
 
 .top {
   display: flex;
   flex-direction: row;
-  
 }
 
-.close_button {
+.title {
+  margin: 0;
+
+  font-size: 24px;
+  font-weight: 700;
+  color: var(--black-medium);
+}
+
+.close-button {
   position: absolute;
-  top: 23px;
-  right: 23px;
+  top: 24px;
+  right: 24px;
+
   background: none;
   border: none;
+
   cursor: pointer;
 }
 
-.cancle_button {
+.cancel-button {
   width: 36px;
-  height: 36px; 
+  height: 36px;
 }
 
 @media screen and (max-width: 743px) {
-  .close_button {
-    top: 30px;
-  }  
+  .modal-section {
+    padding: 24px 16px;
+  }
 
-  .cancle_button {
+  .title {
+    font-size: 20px;
+  }
+
+  .close-button {
+    top: 28px;
+    right: 16px;
+  }
+
+  .cancel-button {
     width: 24px;
-    height: 24px; 
+    height: 24px;
   }
 }

--- a/src/components/common/modal/general/GeneralModal.tsx
+++ b/src/components/common/modal/general/GeneralModal.tsx
@@ -1,67 +1,70 @@
-import Cancle from 'public/ic/ic_x.svg';
+import Cancel from 'public/ic/ic_x.svg';
 import TitleTagInput from '@/components/common/input/info-input/TitleTagInput';
 import CDSButton from '@/components/common/button/CDSButton';
+import OverlayContainer from '../overlay-container/OverlayContainer';
 import styles from './GeneralModal.module.css';
 
 export interface GeneralModalProps {
+  label: string;
   isOpen: boolean;
   onClose: () => void;
   title: string;
   inputValue: string;
   onInputChange: (value: string) => void;
-  cancletitle: string;
-  handleCancleClick: () => void;
-  adapttitle: string;
+  cancelTitle: string;
+  handleCancelClick: () => void;
+  adaptTitle: string;
   handleAdaptClick: () => void;
 }
 
 export default function GeneralModal({
+  label,
   isOpen,
   onClose,
   title,
   inputValue,
   onInputChange,
-  cancletitle,
-  handleCancleClick,
-  adapttitle,
+  cancelTitle,
+  handleCancelClick,
+  adaptTitle,
   handleAdaptClick,
 }: GeneralModalProps) {
   if (!isOpen) return null;
 
   return (
-    <div className={styles.modal_container}>
-      <div className={styles.modal_section}>
+    <OverlayContainer>
+      <div className={styles['modal-section']}>
         <div className={styles.top}>
           <div>
-            <h1>{title}</h1>
+            <h1 className={styles.title}>{title}</h1>
             <button
               type="button"
-              className={styles.close_button}
+              className={styles['close-button']}
               onClick={onClose}
             >
-              <Cancle className={styles.cancle_button} />
+              <Cancel className={styles['cancel-button']} />
             </button>
           </div>
         </div>
         <div className={styles.top}>
           <TitleTagInput
-            label="이름"
+            label={label}
             placeholder="제목을 입력해주세요."
             value={inputValue} // 부모로부터 받은 값
             onChange={(e) => onInputChange(e.target.value)} // 부모로 값 전달
-            required
+            required={false}
           />
         </div>
         <div className={styles.top}>
-          <CDSButton btnType="modal" onClick={handleCancleClick}>
-            {cancletitle}
+          <CDSButton btnType="modal" onClick={handleCancelClick}>
+            {cancelTitle}
           </CDSButton>
           <span style={{ margin: '0 5px' }} />
           <CDSButton btnType="modal_colored" onClick={handleAdaptClick}>
-            {adapttitle}
+            {adaptTitle}
           </CDSButton>
         </div>
       </div>
-    </div>
+    </OverlayContainer>
   );
 }

--- a/src/components/common/modal/general/GeneralModal.tsx
+++ b/src/components/common/modal/general/GeneralModal.tsx
@@ -6,6 +6,7 @@ import styles from './GeneralModal.module.css';
 
 export interface GeneralModalProps {
   label: string;
+  placeholder: string;
   isOpen: boolean;
   onClose: () => void;
   title: string;
@@ -19,6 +20,7 @@ export interface GeneralModalProps {
 
 export default function GeneralModal({
   label,
+  placeholder,
   isOpen,
   onClose,
   title,
@@ -49,7 +51,7 @@ export default function GeneralModal({
         <div className={styles.top}>
           <TitleTagInput
             label={label}
-            placeholder="제목을 입력해주세요."
+            placeholder={placeholder}
             value={inputValue} // 부모로부터 받은 값
             onChange={(e) => onInputChange(e.target.value)} // 부모로 값 전달
             required={false}

--- a/src/components/common/navbar/Navbar.module.css
+++ b/src/components/common/navbar/Navbar.module.css
@@ -56,6 +56,11 @@
   background-color: var(--gray-medium);
 }
 
+.dropdown div > ul {
+  top: 50px;
+  right: -10px;
+}
+
 @media screen and (max-width: 1199px) {
   .navbar {
     padding: 0 32px 0 0;

--- a/src/components/common/navbar/Navbar.tsx
+++ b/src/components/common/navbar/Navbar.tsx
@@ -1,13 +1,14 @@
 import styles from './Navbar.module.css';
-import { useEffect, useState } from 'react';
+import { ChangeEvent, useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import { useSelector } from 'react-redux';
 import { RootState } from '@/redux/store';
 import NavButton from '../button/NavButton';
 import UserProfile from '../userprofile/UserProfile';
 import InvitedMember from '../invitedmember/InvitedMember';
-import { getDashboard, getMember } from '@/lib/navbar/getNavbar';
+import GeneralModal from '../modal/general/GeneralModal';
 import Dropdown from '../dropdown/Dropdown';
+import { getDashboard, getMember } from '@/lib/navbar/getNavbar';
 
 function Navbar() {
   const [dashboardData, setDashboardData] = useState(null);
@@ -15,6 +16,13 @@ function Navbar() {
   const user = useSelector((state: RootState) => state.userInfo.user);
   const [clientUser, setClientUser] = useState(null);
   const router = useRouter();
+  // 모달
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [emailValue, setEmailValue] = useState('');
+
+  const handleCancelClick = () => {
+    setIsModalOpen(false);
+  };
 
   const isMyDashboard = router.pathname !== '/mydashboard';
   const isMyPage = router.pathname !== '/mypage';
@@ -82,7 +90,21 @@ function Navbar() {
             <NavButton
               btnType="invite"
               buttonName="초대하기"
-              onClick={() => alert('초대하기')}
+              onClick={() => setIsModalOpen(true)}
+            />
+
+            <GeneralModal
+              label="이메일"
+              placeholder="이메일을 입력해 주세요"
+              isOpen={isModalOpen}
+              onClose={handleCancelClick}
+              title="초대하기"
+              inputValue={emailValue}
+              onInputChange={(value) => setEmailValue(value)}
+              cancelTitle="취소"
+              adaptTitle="초대"
+              handleCancelClick={handleCancelClick}
+              handleAdaptClick={() => alert('초대')}
             />
 
             <InvitedMember invitedMember={invitedMember} />

--- a/src/components/common/navbar/Navbar.tsx
+++ b/src/components/common/navbar/Navbar.tsx
@@ -1,4 +1,3 @@
-import Link from 'next/link';
 import styles from './Navbar.module.css';
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
@@ -8,6 +7,7 @@ import NavButton from '../button/NavButton';
 import UserProfile from '../userprofile/UserProfile';
 import InvitedMember from '../invitedmember/InvitedMember';
 import { getDashboard, getMember } from '@/lib/navbar/getNavbar';
+import Dropdown from '../dropdown/Dropdown';
 
 function Navbar() {
   const [dashboardData, setDashboardData] = useState(null);
@@ -53,6 +53,15 @@ function Navbar() {
     );
   };
 
+  const handleDropdownClick = (value: string) => {
+    if (value === 'mypage') {
+      router.push('/mypage');
+    } else if (value === 'logout') {
+      sessionStorage.removeItem('accessToken');
+      router.push('/');
+    }
+  };
+
   return (
     <div className={styles.navbar}>
       {renderTitle()}
@@ -80,15 +89,23 @@ function Navbar() {
           </div>
         )}
 
-        <Link href={'/mypage'}>
-          {clientUser && (
-            <UserProfile
-              type="header"
-              nickname={clientUser.nickname}
-              profileImageUrl={clientUser.profileImageUrl}
-            />
-          )}
-        </Link>
+        <div className={styles.dropdown}>
+          <Dropdown
+            onMenuClick={handleDropdownClick}
+            menus={[
+              { label: '마이페이지', value: 'mypage' },
+              { label: '로그아웃', value: 'logout' },
+            ]}
+          >
+            {clientUser && (
+              <UserProfile
+                type="header"
+                nickname={clientUser.nickname}
+                profileImageUrl={clientUser.profileImageUrl}
+              />
+            )}
+          </Dropdown>
+        </div>
       </div>
     </div>
   );

--- a/src/components/dashboard/column/Column.tsx
+++ b/src/components/dashboard/column/Column.tsx
@@ -145,6 +145,7 @@ function Column({
       {isEditModalOpen && (
         <GeneralModal
           label="이름"
+          placeholder="수정할 이름을 입력해 주세요"
           isOpen={isEditModalOpen}
           onClose={closeEditModal}
           title="컬럼 제목 수정"

--- a/src/components/dashboard/column/Column.tsx
+++ b/src/components/dashboard/column/Column.tsx
@@ -11,9 +11,7 @@ import useModal from '@/hooks/useModal';
 import deleteColumns from '@/lib/dashboard/deleteColumns';
 import { Column as ColumnType } from '@/type/column';
 import DeleteCardsModal from '@/components/common/modal/delete-cards/DeleteCardsModal';
-import OverlayContainer from '@/components/common/modal/overlay-container/OverlayContainer';
 import CreateCard from '@/components/product/dashboard/card/CreateCard';
-
 
 interface ColumnProp {
   columnId: number;
@@ -29,19 +27,26 @@ function Column({
   const { columnData, setColumnData, fetchCards } = useColumnData(columnId);
   const [columnTitle, setColumnTitle] = useState(initialTitle);
   const [editedTitle, setEditedTitle] = useState(columnTitle);
+  const [modal, setModal] = useState(false); // 카드 생성 모달 띄우기 위한 state
+
+  const handleClick = () => {
+    // 카드 생성 모달 띄우기 위한 함수
+    setModal(true);
+  };
 
   const {
     isOpen: isEditModalOpen,
     openModal: openEditModal,
     closeModal: closeEditModal,
   } = useModal();
+
   const {
     isOpen: isConfirmModalOpen,
     openModal: openConfirmModal,
     closeModal: closeConfirmModal,
   } = useModal();
 
-  const handleCancleClick = () => {
+  const handleCancelClick = () => {
     closeEditModal();
     openConfirmModal();
   };
@@ -75,11 +80,6 @@ function Column({
     } catch (error) {
       alert(error.message || '컬럼 제목 수정 중 오류가 발생했습니다.');
     }
-  const [modal, setModal] = useState(false); // 카드 생성 모달 띄우기 위한 state
-
-  const handleClick = () => {
-    // 카드 생성 모달 띄우기 위한 함수수
-    setModal(true);
   };
 
   const handleObserver = useCallback(
@@ -144,27 +144,28 @@ function Column({
       {/* 모달창 - 수정 */}
       {isEditModalOpen && (
         <GeneralModal
+          label="이름"
           isOpen={isEditModalOpen}
           onClose={closeEditModal}
           title="컬럼 제목 수정"
           inputValue={editedTitle}
           onInputChange={(value) => setEditedTitle(value)}
-          cancletitle="삭제"
-          handleCancleClick={handleCancleClick}
-          adapttitle="변경"
+          cancelTitle="삭제"
+          handleCancelClick={handleCancelClick}
+          adaptTitle="변경"
           handleAdaptClick={handleAdaptClick}
         />
       )}
+
       {/* 모달창 - 삭제 */}
       {isConfirmModalOpen && (
-        <OverlayContainer>
-          <DeleteCardsModal
-            message="컬럼의 모든 카드가 삭제됩니다."
-            handleCancelClick={() => closeConfirmModal()}
-            handleDeleteClick={handleDeleteClick}
-          />
-        </OverlayContainer>
+        <DeleteCardsModal
+          message="컬럼의 모든 카드가 삭제됩니다."
+          handleCancelClick={() => closeConfirmModal()}
+          handleDeleteClick={handleDeleteClick}
+        />
       )}
+
       {modal && ( // 카드 생성 모달 띄우기기
         <CreateCard
           columnId={columnId}

--- a/src/components/product/auth/SigninForm.tsx
+++ b/src/components/product/auth/SigninForm.tsx
@@ -6,7 +6,6 @@ import { setUserInfo } from '@/redux/settingSlice';
 import { AppDispatch } from '@/redux/store';
 import AuthInput from '@/components/common/input/auth-input/AuthInput';
 import CDSButton from '@/components/common/button/CDSButton';
-import OverlayContainer from '@/components/common/modal/overlay-container/OverlayContainer';
 import AuthModal from '@/components/common/modal/auth/AuthModal';
 import { postSignin } from '@/lib/signin/postSignin';
 import { ERROR_MESSAGE, PLACEHOLDER } from '@/constants/messages';
@@ -124,12 +123,10 @@ function SigninForm() {
       </form>
 
       {isModalVisible && (
-        <OverlayContainer>
-          <AuthModal
-            message={responseMessage}
-            handleCancelClick={handleCancelClick}
-          />
-        </OverlayContainer>
+        <AuthModal
+          message={responseMessage}
+          handleCancelClick={handleCancelClick}
+        />
       )}
     </>
   );

--- a/src/components/product/auth/SignupForm.tsx
+++ b/src/components/product/auth/SignupForm.tsx
@@ -7,7 +7,6 @@ import { AppDispatch } from '@/redux/store';
 import AuthInput from '@/components/common/input/auth-input/AuthInput';
 import CheckBox from '@/components/common/checkbox/CheckBox';
 import CDSButton from '@/components/common/button/CDSButton';
-import OverlayContainer from '@/components/common/modal/overlay-container/OverlayContainer';
 import AuthModal from '@/components/common/modal/auth/AuthModal';
 import { postSignup } from '@/lib/signup/postSignup';
 import { postSignin } from '@/lib/signin/postSignin';
@@ -195,12 +194,10 @@ function SignupForm() {
       </form>
 
       {isModalVisible && (
-        <OverlayContainer>
-          <AuthModal
-            message={responseMessage}
-            handleCancelClick={handleCancelClick}
-          />
-        </OverlayContainer>
+        <AuthModal
+          message={responseMessage}
+          handleCancelClick={handleCancelClick}
+        />
       )}
     </>
   );

--- a/src/components/product/mypage/ChangePassword.tsx
+++ b/src/components/product/mypage/ChangePassword.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react';
 import clsx from 'clsx';
 import changePassword from '@/lib/mypage/changePassword';
 import CDSButton from '@/components/common/button/CDSButton';
-import OverlayContainer from '@/components/common/modal/overlay-container/OverlayContainer';
 import AuthModal from '@/components/common/modal/auth/AuthModal';
 import styles from './ChangePassword.module.css';
 
@@ -128,14 +127,12 @@ export default function ChangePassword({
         </CDSButton>
       </div>
       {modal && (
-        <OverlayContainer>
-          <AuthModal
-            message={
-              errorMessage ? errorMessage : '비밀번호 변경이 완료되었습니다.'
-            }
-            handleCancelClick={handleCancelClick}
-          />
-        </OverlayContainer>
+        <AuthModal
+          message={
+            errorMessage ? errorMessage : '비밀번호 변경이 완료되었습니다.'
+          }
+          handleCancelClick={handleCancelClick}
+        />
       )}
     </section>
   );

--- a/src/components/product/mypage/ProfileModifyModal.tsx
+++ b/src/components/product/mypage/ProfileModifyModal.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import OverlayContainer from '@/components/common/modal/overlay-container/OverlayContainer';
 import AuthModal from '@/components/common/modal/auth/AuthModal';
 
 interface ProfileModifyModalProps {
@@ -11,9 +10,5 @@ export default function ProfileModifyModal({
   message,
   onCancel,
 }: ProfileModifyModalProps) {
-  return (
-    <OverlayContainer>
-      <AuthModal message={message} handleCancelClick={onCancel} />
-    </OverlayContainer>
-  );
+  return <AuthModal message={message} handleCancelClick={onCancel} />;
 }

--- a/src/pages/dashboard/Dashboard.module.css
+++ b/src/pages/dashboard/Dashboard.module.css
@@ -5,7 +5,6 @@
   width: calc(100% - 280px);
   height: calc(100vh - 70px);
 
-  margin-top: 70px;
   margin-left: 280px;
 
   background-color: var(--gray-brightes);
@@ -45,7 +44,6 @@
     width: calc(calc(100% - 67px));
     height: calc(100vh - 60px);
 
-    margin-top: 60px;
     margin-left: 67px;
   }
 

--- a/src/pages/dashboard/[id].tsx
+++ b/src/pages/dashboard/[id].tsx
@@ -8,6 +8,7 @@ import Column from '@/components/dashboard/column/Column';
 import { Column as ColumnType } from '@/type/column';
 import { useRouter } from 'next/router';
 import GeneralModal from '@/components/common/modal/general/GeneralModal';
+import Navbar from '@/components/common/navbar/Navbar';
 
 function DashBoard() {
   const { query } = useRouter();
@@ -21,7 +22,7 @@ function DashBoard() {
     setNewColumn('');
   };
 
-  const handleCancleClick = () => {
+  const handleCancelClick = () => {
     closeModal();
   };
 
@@ -65,6 +66,7 @@ function DashBoard() {
   return (
     <div>
       <Sidebar />
+      <Navbar />
       <div className={styles.container}>
         {columns.map(({ id, title }) => (
           <Column
@@ -84,14 +86,16 @@ function DashBoard() {
       {/* 모달창 */}
       {showModal && (
         <GeneralModal
+          label="이름"
+          placeholder="컬럼 이름을 입력해 주세요"
           isOpen={showModal}
           onClose={closeModal}
           title="새로운 컬럼 추가"
           inputValue={newColumn}
           onInputChange={(value) => setNewColumn(value)}
-          cancletitle="취소"
-          handleCancleClick={handleCancleClick}
-          adapttitle="생성"
+          cancelTitle="취소"
+          handleCancelClick={handleCancelClick}
+          adaptTitle="생성"
           handleAdaptClick={handleAdaptClick}
         />
       )}


### PR DESCRIPTION
### 이슈 번호

close #102 

### 변경 사항 요약

- Navbar의 프로필 클릭 시 dropdown으로 마이페이지, 로그아웃할 수 있도록 하였습니다.
- 대시보드 상세 페이지 Navbar 적용했습니다.
- 모달 오버레이 전체적으로 수정하였고 모든 모달 정상 동작하는 거 확인했습니다.

### 테스트 결과
<img width="1702" alt="스크린샷 2024-12-19 22 31 16" src="https://github.com/user-attachments/assets/201493e1-0d05-496b-9093-e052286548ba" />

### 현재 초대하기 작업 중인데, 이번 작업이 다른 분들 작업 파일이 섞여있어 충돌이 우려되어 빨리 PR 올렸습니다. 초대하기 기능은 새로운 이슈 생성하여 작업 이어하겠습니다.