### PR TITLE
#100 페이지 로그인페이지

### DIFF
--- a/src/components/common/navbar/Navbar.tsx
+++ b/src/components/common/navbar/Navbar.tsx
@@ -81,6 +81,7 @@ function Navbar() {
     if (value === 'mypage') {
       router.push('/mypage');
     } else if (value === 'logout') {
+      localStorage.removeItem('accessToken');
       sessionStorage.removeItem('accessToken');
       router.push('/');
     }

--- a/src/components/product/auth/SigninForm.tsx
+++ b/src/components/product/auth/SigninForm.tsx
@@ -26,17 +26,24 @@ function SigninForm() {
   const router = useRouter();
   const dispatch = useDispatch<AppDispatch>();
 
+  // localStorage에서 email 가져오기
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const email = localStorage.getItem('email');
+      if (email) {
+        setValues((prevValues) => ({
+          ...prevValues,
+          email,
+        }));
+      }
+    }
+  }, []);
+
   useEffect(() => {
     const isEmailValid = emailValidation(values.email);
     const isPasswordValid = passwordValidation(values.password);
     setDisabled(!(isEmailValid && isPasswordValid));
   }, [values]);
-
-  useEffect(() => {
-    if (sessionStorage.getItem('accessToken')) {
-      router.push('/mydashboard');
-    }
-  }, []);
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
@@ -71,6 +78,8 @@ function SigninForm() {
         }),
       );
 
+      localStorage.setItem('email', values.email);
+
       router.push('/mydashboard');
     } catch (error) {
       setResponseMessage(error.message);
@@ -82,6 +91,7 @@ function SigninForm() {
     setIsModalVisible(false);
     setResponseMessage(null);
   };
+
   return (
     <>
       <form onSubmit={onSubmit}>

--- a/src/components/product/auth/SigninForm.tsx
+++ b/src/components/product/auth/SigninForm.tsx
@@ -4,12 +4,12 @@ import { useRouter } from 'next/router';
 import { useDispatch } from 'react-redux';
 import { setUserInfo } from '@/redux/settingSlice';
 import { AppDispatch } from '@/redux/store';
-import AuthInput from '@/components/common/input/auth-input/AuthInput';
-import CDSButton from '@/components/common/button/CDSButton';
-import AuthModal from '@/components/common/modal/auth/AuthModal';
 import { postSignin } from '@/lib/signin/postSignin';
 import { ERROR_MESSAGE, PLACEHOLDER } from '@/constants/messages';
 import { emailValidation, passwordValidation } from '@/utils/authValidation';
+import AuthInput from '@/components/common/input/auth-input/AuthInput';
+import CDSButton from '@/components/common/button/CDSButton';
+import AuthModal from '@/components/common/modal/auth/AuthModal';
 import CheckBox from '@/components/common/checkbox/CheckBox';
 
 const INITIAL_VALUES = {
@@ -21,12 +21,14 @@ function SigninForm() {
   const [values, setValues] = useState(INITIAL_VALUES);
   const [emailValid, setEmailValid] = useState(false);
   const [passwordValid, setPasswordValid] = useState(false);
-  const [disabled, setDisabled] = useState(true);
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [responseMessage, setResponseMessage] = useState('');
   const [isChecked, setIsChecked] = useState(false);
   const router = useRouter();
   const dispatch = useDispatch<AppDispatch>();
+
+  const isEmailValid = emailValidation(values.email);
+  const isPasswordValid = passwordValidation(values.password);
 
   // localStorage에서 email 가져오기
   useEffect(() => {
@@ -40,12 +42,6 @@ function SigninForm() {
       }
     }
   }, []);
-
-  useEffect(() => {
-    const isEmailValid = emailValidation(values.email);
-    const isPasswordValid = passwordValidation(values.password);
-    setDisabled(!(isEmailValid && isPasswordValid));
-  }, [values]);
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
@@ -93,15 +89,6 @@ function SigninForm() {
     }
   };
 
-  const handleCancelClick = () => {
-    setIsModalVisible(false);
-    setResponseMessage(null);
-  };
-
-  const onChange = () => {
-    setIsChecked(!isChecked);
-  };
-
   return (
     <>
       <form onSubmit={onSubmit}>
@@ -140,11 +127,15 @@ function SigninForm() {
           id="login"
           htmlFor="login"
           text="로그인 상태 유지"
-          onChange={onChange}
+          onChange={() => setIsChecked(!isChecked)}
         />
 
         <div className={styles['login-button']}>
-          <CDSButton btnType="auth" type="submit" disabled={disabled}>
+          <CDSButton
+            btnType="auth"
+            type="submit"
+            disabled={!(isEmailValid && isPasswordValid)}
+          >
             로그인
           </CDSButton>
         </div>
@@ -153,7 +144,10 @@ function SigninForm() {
       {isModalVisible && (
         <AuthModal
           message={responseMessage}
-          handleCancelClick={handleCancelClick}
+          handleCancelClick={() => {
+            setIsModalVisible(false);
+            setResponseMessage(null);
+          }}
         />
       )}
     </>

--- a/src/components/product/auth/SigninForm.tsx
+++ b/src/components/product/auth/SigninForm.tsx
@@ -10,6 +10,7 @@ import AuthModal from '@/components/common/modal/auth/AuthModal';
 import { postSignin } from '@/lib/signin/postSignin';
 import { ERROR_MESSAGE, PLACEHOLDER } from '@/constants/messages';
 import { emailValidation, passwordValidation } from '@/utils/authValidation';
+import CheckBox from '@/components/common/checkbox/CheckBox';
 
 const INITIAL_VALUES = {
   email: '',
@@ -23,6 +24,7 @@ function SigninForm() {
   const [disabled, setDisabled] = useState(true);
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [responseMessage, setResponseMessage] = useState('');
+  const [isChecked, setIsChecked] = useState(false);
   const router = useRouter();
   const dispatch = useDispatch<AppDispatch>();
 
@@ -69,7 +71,11 @@ function SigninForm() {
 
     try {
       const response = await postSignin(values);
-      sessionStorage.setItem('accessToken', response.accessToken);
+      if (isChecked) {
+        localStorage.setItem('accessToken', response.accessToken);
+      } else {
+        sessionStorage.setItem('accessToken', response.accessToken);
+      }
 
       // 리덕스 액션 호출
       dispatch(
@@ -90,6 +96,10 @@ function SigninForm() {
   const handleCancelClick = () => {
     setIsModalVisible(false);
     setResponseMessage(null);
+  };
+
+  const onChange = () => {
+    setIsChecked(!isChecked);
   };
 
   return (
@@ -123,6 +133,14 @@ function SigninForm() {
           error={passwordValid}
           errorMessage={ERROR_MESSAGE.PASSWORD_MIN_LENGTH}
           autoComplete="password"
+        />
+
+        <CheckBox
+          name="login"
+          id="login"
+          htmlFor="login"
+          text="로그인 상태 유지"
+          onChange={onChange}
         />
 
         <div className={styles['login-button']}>

--- a/src/hooks/useAuthRedirect.ts
+++ b/src/hooks/useAuthRedirect.ts
@@ -1,0 +1,28 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+
+export default function useAuthRedirect() {
+  const [isAuthStatus, setIsAuthStatus] = useState(false);
+  const router = useRouter();
+
+  useEffect(() => {
+    // 클라이언트 환경에서만 스토리지 접근
+    if (typeof window !== 'undefined') {
+      const accessToken =
+        localStorage.getItem('accessToken') ||
+        sessionStorage.getItem('accessToken');
+
+      if (accessToken) {
+        setIsAuthStatus(true);
+        router.push('/mydashboard'); // 인증된 사용자는 대시보드로 리다이렉션
+      }
+    }
+  }, [router]);
+
+  // 인증 상태 확인 중이라면 아무것도 렌더링하지 않음
+  if (isAuthStatus) {
+    return null;
+  }
+
+  return true;
+}

--- a/src/lib/instance.ts
+++ b/src/lib/instance.ts
@@ -7,9 +7,13 @@ const instance = axios.create({
 });
 
 instance.interceptors.request.use((config) => {
-  const token = sessionStorage.getItem('accessToken');
-  if (token) {
-    config.headers.Authorization = `Bearer ${token}`;
+  const localStorageToken = localStorage.getItem('accessToken');
+  const sessionStorageToken = sessionStorage.getItem('accessToken');
+
+  if (localStorageToken) {
+    config.headers.Authorization = `Bearer ${localStorageToken}`;
+  } else if (sessionStorageToken) {
+    config.headers.Authorization = `Bearer ${sessionStorageToken}`;
   }
   return config;
 });

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,8 +1,16 @@
 import Header from '@/components/product/landing/Header';
 import Main from '@/components/product/landing/Main';
 import Footer from '@/components/product/landing/Footer';
+import useAuthRedirect from '@/hooks/useAuthRedirect';
 
 export default function Home() {
+  const isNotRedirected = useAuthRedirect();
+
+  if (!isNotRedirected) {
+    return null; // 인증 확인 중이면 아무것도 렌더링하지 않음
+  }
+
+  // 인증되지 않은 사용자만 페이지 렌더링
   return (
     <div
       style={{

--- a/src/pages/signin/index.module.css
+++ b/src/pages/signin/index.module.css
@@ -1,12 +1,14 @@
 .signin-container {
   margin: 223px auto 158px auto;
+
   width: 520px;
 }
 
 .logo {
+  margin: 0 auto;
+
   width: 200px;
   height: 280px;
-  margin: 0 auto;
 }
 
 .logo svg {
@@ -15,16 +17,18 @@
 }
 
 .text {
+  margin: 10px 0 30px;
+
   font-size: 20px;
   font-weight: 500;
   line-height: 32px;
   color: var(--black-medium);
   text-align: center;
-  margin: 10px 0 30px;
 }
 
 .link-text {
   margin-top: 24px;
+
   font-size: 16px;
   font-weight: 400;
   text-align: center;
@@ -38,12 +42,14 @@
 @media screen and (max-width: 743px) {
   .signin-container {
     margin: 73px auto 0 auto;
+
     width: 350px;
   }
 
   .text {
+    margin: 8px 0 36px;
+
     font-size: 18px;
     line-height: 26px;
-    margin: 8px 0 36px;
   }
 }

--- a/src/pages/signin/index.tsx
+++ b/src/pages/signin/index.tsx
@@ -1,19 +1,17 @@
 import Link from 'next/link';
-import { useEffect } from 'react';
-import { useRouter } from 'next/router';
 import styles from './index.module.css';
 import SigninForm from '@/components/product/auth/SigninForm';
+import useAuthRedirect from '@/hooks/useAuthRedirect';
 import Logo from 'public/images/img_signinlogo.svg';
 
 function SignIn() {
-  const router = useRouter();
+  const isNotRedirected = useAuthRedirect();
 
-  useEffect(() => {
-    if (sessionStorage.getItem('accessToken')) {
-      router.push('/mydashboard');
-    }
-  }, []);
+  if (!isNotRedirected) {
+    return null; // 인증 확인 중이면 아무것도 렌더링하지 않음
+  }
 
+  // 인증되지 않은 사용자만 페이지 렌더링
   return (
     <>
       <div className={styles['signin-container']}>

--- a/src/pages/signin/index.tsx
+++ b/src/pages/signin/index.tsx
@@ -1,9 +1,19 @@
 import Link from 'next/link';
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
 import styles from './index.module.css';
 import SigninForm from '@/components/product/auth/SigninForm';
 import Logo from 'public/images/img_signinlogo.svg';
 
 function SignIn() {
+  const router = useRouter();
+
+  useEffect(() => {
+    if (sessionStorage.getItem('accessToken')) {
+      router.push('/mydashboard');
+    }
+  }, []);
+
   return (
     <>
       <div className={styles['signin-container']}>

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -1,9 +1,17 @@
 import Link from 'next/link';
 import styles from '../signin/index.module.css';
 import SignupForm from '@/components/product/auth/SignupForm';
+import useAuthRedirect from '@/hooks/useAuthRedirect';
 import Logo from 'public/images/img_signinlogo.svg';
 
 function SignUp() {
+  const isNotRedirected = useAuthRedirect();
+
+  if (!isNotRedirected) {
+    return null; // 인증 확인 중이면 아무것도 렌더링하지 않음
+  }
+
+  // 인증되지 않은 사용자만 페이지 렌더링
   return (
     <>
       <div className={styles['signin-container']}>

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -4,12 +4,21 @@ import { DashboardState } from '@/type/dashboard';
 import userInfoReducer from './settingSlice';
 import dashboardReducer from './dashboardSlice';
 
-// 최초 세션 스토리지에서 상태를 로드하는 함수
+// 스토리지 선택 함수 (localStorage 또는 sessionStorage)
+const getStorage = () => {
+  if (typeof window !== 'undefined') {
+    const token = localStorage.getItem('accessToken');
+    return token ? localStorage : sessionStorage;
+  }
+  return null;
+};
+
+// 초기 상태를 스토리지에서 로드하는 함수
 const loadState = () => {
   try {
-    // 브라우저 환경에서만 sessionStorage를 사용하도록 조건 추가
-    if (typeof window !== 'undefined') {
-      const storedState = sessionStorage.getItem('userState');
+    const storage = getStorage();
+    if (storage) {
+      const storedState = storage.getItem('userState');
       if (!storedState) return undefined;
 
       return JSON.parse(storedState); // 문자열로 저장된 JSON을 객체로 변환하여 반환
@@ -24,7 +33,7 @@ const loadState = () => {
 // 스토어 설정
 const store = configureStore({
   reducer: {
-    userInfo: userInfoReducer, // userInfo 상태를 처리하는 리듀서를 설정
+    userInfo: userInfoReducer,
     dashboard: dashboardReducer,
   } as any,
   preloadedState: loadState() as { userInfo: UserInfoState }, // 새로 고침 되어도 이전 상태 유지
@@ -37,11 +46,14 @@ export type RootState = {
 };
 export type AppDispatch = typeof store.dispatch;
 
-// Redux Store 상태 변경 시 sessionStorage에 저장
+// Redux Store 상태 변경 시 스토리지에 저장
 store.subscribe(() => {
   try {
-    const stateToSave = JSON.stringify(store.getState()); // store의 상태를 문자열로 변환
-    sessionStorage.setItem('userState', stateToSave);
+    const storage = getStorage();
+    if (storage) {
+      const stateToSave = JSON.stringify(store.getState()); // store의 상태를 문자열로 변환
+      storage.setItem('userState', stateToSave);
+    }
   } catch (error) {
     console.error('상태를 저장하는데 실패했어요:', error);
   }


### PR DESCRIPTION
### 이슈 번호

close #100 

### 변경 사항 요약

- 로그인에 입력한 이메일을 로컬 스토리지에 저장하여, 다음 로그인에 로컬 스토리지에 저장된 이메일 화면에 뿌려줌.
- 로컬 스토리지를 활용한 로그인 상태 유지 기능 추가
- 메인, 로그인, 회원가입 페이지 엑세스 토큰 데이터가 있으면 나의 대시보드 페이지로 리다이렉트

### 테스트 결과
https://github.com/user-attachments/assets/17b5ef2b-c0ed-48e9-8d7e-599e5d5e4b1f