### PR TITLE
#123 카드 이미지 확장자 제한

### DIFF
--- a/src/components/product/dashboard/card/CardImageInput.tsx
+++ b/src/components/product/dashboard/card/CardImageInput.tsx
@@ -34,6 +34,7 @@ export default function CardImageInput({
         id="profile-image"
         onChange={onImageChange}
         className={styles[`img-input`]}
+        accept=".gif, .jpg, .png"
       />
     </div>
   );

--- a/src/hooks/useCardImageUploader.ts
+++ b/src/hooks/useCardImageUploader.ts
@@ -7,6 +7,18 @@ export default function useCardImageUploader() {
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) {
+      const allowedExtensions = ['png', 'gif', 'jpg', 'jpeg'];
+
+      // 이미지 확장자
+      const fileExtension = file.name.split('.').pop()?.toLowerCase();
+
+      // 확장자 검증
+      if (!fileExtension || !allowedExtensions.includes(fileExtension)) {
+        alert('허용되지 않는 파일 형식입니다 (png, gif, jpg만 등록 가능)');
+        // e.target.value = '';
+        return;
+      }
+
       setImage(file);
       const imgURL = URL.createObjectURL(file);
       setPreview(imgURL);

--- a/src/hooks/useCardImageUploader.ts
+++ b/src/hooks/useCardImageUploader.ts
@@ -15,7 +15,6 @@ export default function useCardImageUploader() {
       // 확장자 검증
       if (!fileExtension || !allowedExtensions.includes(fileExtension)) {
         alert('허용되지 않는 파일 형식입니다 (png, gif, jpg만 등록 가능)');
-        // e.target.value = '';
         return;
       }
 


### PR DESCRIPTION
### 이슈 번호

close #123 

### 변경 사항 요약

- 이미지 Input 확장자를 png, gif, jpg로 제한했습니다.
- 이미지 등록 핸들러에 확장자 validation을 추가했습니다. (사용자가 확장자 모든 파일로 바꾸는 경우 고려)

### 테스트 결과
https://github.com/user-attachments/assets/5e53cb9a-720b-4373-a6ed-d93e63eeeecd
#### 이미지 input 초기 화면(gif, png, jpg만 선택 가능하도록 제한)
![localhost_3000_dashboard_12794 - Chrome 2024-12-21 오전 11_45_47](https://github.com/user-attachments/assets/8bcdd3c3-2ade-4c86-bda3-2e6f86923048)
#### 사용자가 모든 파일을 선택한 경우
![localhost_3000_dashboard_12794 - Chrome 2024-12-21 오전 11_45_55](https://github.com/user-attachments/assets/1d273abd-0d32-4a72-8b26-e93a35c19826)
#### Image 확장자 validation
![localhost_3000_dashboard_12794 - Chrome 2024-12-21 오전 11_46_03](https://github.com/user-attachments/assets/dd80a35b-2683-41ed-a30b-d373672ce7f6)




### 리뷰포인트