### PR TITLE
#127 request body에 tag 색상 반영하도록 수정

### DIFF
--- a/src/components/common/chip/Chip.tsx
+++ b/src/components/common/chip/Chip.tsx
@@ -22,11 +22,7 @@ function Chip({ children, chipType, color }: PropsWithChildren<ChipProps>) {
   const renderDot = () =>
     chipType.startsWith('status') && <span className={styles.dot} />;
 
-  const className = clsx(
-    styles[chipType],
-    chipType === 'tag' && styles[color],
-    // chipType === 'tag' && getTagColor(styles),
-  );
+  const className = clsx(styles[chipType], chipType === 'tag' && styles[color]);
 
   return (
     <span className={className}>

--- a/src/components/common/chip/Chip.tsx
+++ b/src/components/common/chip/Chip.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx';
 import { ChipProps } from '@/type/chip';
 import { PropsWithChildren } from 'react';
 import styles from './Chip.module.css';
-import getTagColor from './helper';
+// import getTagColor from './helper';
 
 /**
  * Chip 컴포넌트
@@ -13,7 +13,7 @@ import getTagColor from './helper';
  * @param {React.ReactNode} props.children - Chip 내부에 렌더링할 내용
  * @returns {JSX.Element} Chip 컴포넌트의
  */
-function Chip({ children, chipType }: PropsWithChildren<ChipProps>) {
+function Chip({ children, chipType, color }: PropsWithChildren<ChipProps>) {
   /**
    * renderDot: status인 타입인 경우 점을 렌더링
    * - 조건: chipType.startsWith('status') -> status | status-option
@@ -24,7 +24,8 @@ function Chip({ children, chipType }: PropsWithChildren<ChipProps>) {
 
   const className = clsx(
     styles[chipType],
-    chipType === 'tag' && getTagColor(styles),
+    chipType === 'tag' && styles[color],
+    // chipType === 'tag' && getTagColor(styles),
   );
 
   return (

--- a/src/components/common/chip/helper.ts
+++ b/src/components/common/chip/helper.ts
@@ -1,18 +1,5 @@
 import { bgTag } from '@/type/chip';
 
-/**
- * 랜덤한 tag 클래스를 반환하는 함수
- * - bgTag 배열에서 랜덤하게 선택
- *
- * @param {Record<string, string>} styles - 스타일 객체
- * @returns {string} 랜덤 배경색 클래스 이름
- */
-// const getTagColor = (styles: Record<string, string>): string => {
-//   if (!bgTag || bgTag.length === 0) return '';
-//   const idx = Math.floor(Math.random() * bgTag.length);
-//   return styles[bgTag[idx]];
-// };
-
 const getTagColor = (): string => {
   if (!bgTag || bgTag.length === 0) return '';
   const idx = Math.floor(Math.random() * bgTag.length);

--- a/src/components/common/chip/helper.ts
+++ b/src/components/common/chip/helper.ts
@@ -7,10 +7,16 @@ import { bgTag } from '@/type/chip';
  * @param {Record<string, string>} styles - 스타일 객체
  * @returns {string} 랜덤 배경색 클래스 이름
  */
-const getTagColor = (styles: Record<string, string>): string => {
+// const getTagColor = (styles: Record<string, string>): string => {
+//   if (!bgTag || bgTag.length === 0) return '';
+//   const idx = Math.floor(Math.random() * bgTag.length);
+//   return styles[bgTag[idx]];
+// };
+
+const getTagColor = (): string => {
   if (!bgTag || bgTag.length === 0) return '';
   const idx = Math.floor(Math.random() * bgTag.length);
-  return styles[bgTag[idx]];
+  return bgTag[idx];
 };
 
 export default getTagColor;

--- a/src/components/common/modal/detail-cards/ChipSection.tsx
+++ b/src/components/common/modal/detail-cards/ChipSection.tsx
@@ -15,11 +15,14 @@ function ChipSection({ columnTitle, tags, cardId }: ChipSectionProps) {
       </div>
       <span className={styles.bar} />
       <div className={styles.tags}>
-        {tags.map((tag) => (
-          <Chip key={`${cardId}_tag_${tag}`} chipType="tag">
-            {tag}
-          </Chip>
-        ))}
+        {tags.map((tag) => {
+          const [tagText, tagColor] = tag.split('^');
+          return (
+            <Chip key={`${cardId}_tag_${tag}`} chipType="tag" color={tagColor}>
+              {tagText}
+            </Chip>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/components/dashboard/card/Card.tsx
+++ b/src/components/dashboard/card/Card.tsx
@@ -43,11 +43,18 @@ function Card({
           <div className={styles['card-title']}>{title}</div>
           <div className={styles['description-section']}>
             <div className={styles['card-tags']}>
-              {tags.map((tag) => (
-                <Chip key={`${id}_tag_${tag}`} chipType="tag">
-                  {tag}
-                </Chip>
-              ))}
+              {tags.map((tag) => {
+                const [tagText, tagColor] = tag.split('^');
+                return (
+                  <Chip
+                    key={`${id}_tag_${tag}`}
+                    chipType="tag"
+                    color={tagColor}
+                  >
+                    {tagText}
+                  </Chip>
+                );
+              })}
             </div>
             <div className={styles['card-date']}>
               <CalendarIcon className={styles['icon-calendar']} />

--- a/src/components/product/dashboard/card/TagManager.tsx
+++ b/src/components/product/dashboard/card/TagManager.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Chip from '@/components/common/chip/Chip';
 import DeleteButton from 'public/ic/ic_x.svg';
 import TitleTagInput from '@/components/common/input/info-input/TitleTagInput';
+import getTagColor from '@/components/common/chip/helper';
 import styles from './TagManager.module.css';
 
 interface TagManagerProps {
@@ -17,8 +18,11 @@ export default function TagManager({
 }: TagManagerProps) {
   const handleTagInput = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newTag = e.target.value.trim();
+    const color = getTagColor();
+    const coloredTag = `${newTag}^${color}`;
+
     if (!newTag || tags.includes(newTag)) return; // 빈 문자열 또는 중복 태그 방지
-    onAddTag(newTag);
+    onAddTag(coloredTag);
     e.target.value = '';
   };
 
@@ -41,19 +45,22 @@ export default function TagManager({
         required
       />
       <div className={styles.tags}>
-        {tags.map((tag) => (
-          <Chip key={`_${tag}`} chipType="tag">
-            <p className={styles.tag}>
-              {tag}
-              <DeleteButton
-                className={styles[`delete-button`]}
-                width={14}
-                height={14}
-                onClick={() => onRemoveTag(tag)}
-              />
-            </p>
-          </Chip>
-        ))}
+        {tags.map((tag) => {
+          const [tagText, tagColor] = tag.split('^');
+          return (
+            <Chip key={`_${tag}`} chipType="tag" color={tagColor}>
+              <p className={styles.tag}>
+                {tagText}
+                <DeleteButton
+                  className={styles[`delete-button`]}
+                  width={14}
+                  height={14}
+                  onClick={() => onRemoveTag(tag)}
+                />
+              </p>
+            </Chip>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/type/chip.ts
+++ b/src/type/chip.ts
@@ -5,6 +5,9 @@ type ChipType = 'tag' | 'status' | 'status-option';
 export interface ChipProps {
   children: ReactNode;
   chipType: ChipType;
+  color?: BgTagColor;
 }
 
 export const bgTag = ['orange', 'green', 'pink', 'blue'];
+
+export type BgTagColor = (typeof bgTag)[number];


### PR DESCRIPTION
### 이슈 번호

close #127 

### 변경 사항 요약

- 태그 색상 고정되도록 수정했습니다. (request body에 color 추가해서 보냄)

### 테스트 결과

https://github.com/user-attachments/assets/b24084af-1654-443b-a6d0-c18be88254df

서버에 color 값을 함께 보내도록 수정해서, 기존에 생성했던 카드들은 bg 없이 나오는게 정상이니 참고 부탁 드려요.
새로 생성하신 카드나 태그부터 정상 동작합니다.
![image](https://github.com/user-attachments/assets/d181b40b-d354-4dd0-a0ab-a4702e19b677)
