### PR TITLE
♻️ 페이지네이션 버튼 수정

### DIFF
--- a/src/components/common/sidebar/Sidebar.tsx
+++ b/src/components/common/sidebar/Sidebar.tsx
@@ -138,16 +138,20 @@ export default function Sidebar() {
         </div>
 
         <div className={styles.pagination}>
-          <CDSButton
-            btnType="pagination_prev"
-            onClick={() => handlePageChange('prev')}
-            disabled={currentPage === 1 || isSidebarLoading}
-          />
-          <CDSButton
-            btnType="pagination_next"
-            onClick={() => handlePageChange('next')}
-            disabled={currentPage === totalPages || isSidebarLoading}
-          />
+          {totalPages > 1 && (
+            <>
+              <CDSButton
+                btnType="pagination_prev"
+                onClick={() => handlePageChange('prev')}
+                disabled={currentPage === 1 || isSidebarLoading}
+              />
+              <CDSButton
+                btnType="pagination_next"
+                onClick={() => handlePageChange('next')}
+                disabled={currentPage === totalPages || isSidebarLoading}
+              />
+            </>
+          )}
         </div>
       </div>
 

--- a/src/components/product/mydashboard/DashboardList.tsx
+++ b/src/components/product/mydashboard/DashboardList.tsx
@@ -107,23 +107,25 @@ export default function DashboardList() {
       </ul>
 
       {/* 페이지네이션 */}
-      <div className={styles.pagination}>
-        <span className={styles['pagination-text']}>
-          {totalPages} 페이지 중 {currentPage}
-        </span>
-        <div>
-          <CDSButton
-            btnType="pagination_prev"
-            onClick={() => handlePageChange(currentPage - 1)}
-            disabled={currentPage === 1}
-          />
-          <CDSButton
-            btnType="pagination_next"
-            onClick={() => handlePageChange(currentPage + 1)}
-            disabled={currentPage === totalPages}
-          />
+      {totalPages > 1 && (
+        <div className={styles.pagination}>
+          <span className={styles['pagination-text']}>
+            {totalPages} 페이지 중 {currentPage}
+          </span>
+          <div>
+            <CDSButton
+              btnType="pagination_prev"
+              onClick={() => handlePageChange(currentPage - 1)}
+              disabled={currentPage === 1}
+            />
+            <CDSButton
+              btnType="pagination_next"
+              onClick={() => handlePageChange(currentPage + 1)}
+              disabled={currentPage === totalPages}
+            />
+          </div>
         </div>
-      </div>
+      )}
 
       {/* 모달창 */}
       {showModal && (


### PR DESCRIPTION
페이지가 1페이지 이하일 때 페이지네이션 버튼이 안보이게 수정했습니다.

### 이슈 번호

close #120 

### 변경 사항 요약

- 1페이지 이하일 때 페이지네이션 버튼이 안보이도록 수정했습니다

### 테스트 결과
![image](https://github.com/user-attachments/assets/a895bf7e-c959-4e21-a3c7-203820584310)


### 리뷰포인트