### PR TITLE
#138 할 일 카드 모달 이슈 수정

### DIFF
--- a/src/components/common/chip/Chip.module.css
+++ b/src/components/common/chip/Chip.module.css
@@ -11,6 +11,8 @@
 }
 
 .status {
+  max-width: 100%;
+
   font-size: 12px;
   line-height: 18px;
 }
@@ -48,6 +50,8 @@
 }
 
 .dot {
+  flex-shrink: 0;
+
   display: inline-block;
   width: 6px;
   height: 6px;

--- a/src/components/common/modal/detail-cards/ChipSection.module.css
+++ b/src/components/common/modal/detail-cards/ChipSection.module.css
@@ -9,6 +9,23 @@
   flex-shrink: 0;
 }
 
+.status > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.status > span > span {
+  flex-shrink: 0;
+}
+
+.status .status-text {
+  max-width: 80px;
+
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .bar {
   width: 1px;
   height: 20px;

--- a/src/components/common/modal/detail-cards/ChipSection.tsx
+++ b/src/components/common/modal/detail-cards/ChipSection.tsx
@@ -11,7 +11,9 @@ function ChipSection({ columnTitle, tags, cardId }: ChipSectionProps) {
   return (
     <div className={styles['chip-section']}>
       <div className={styles.status}>
-        <Chip chipType="status">{columnTitle}</Chip>
+        <Chip chipType="status">
+          <span className={styles['status-text']}>{columnTitle}</span>
+        </Chip>
       </div>
       <span className={styles.bar} />
       <div className={styles.tags}>

--- a/src/components/common/modal/detail-cards/DetailCardModal.module.css
+++ b/src/components/common/modal/detail-cards/DetailCardModal.module.css
@@ -12,12 +12,18 @@
 }
 
 .title {
+  overflow: hidden;
+  height: 32px;
+
+  margin-right: 84px;
   margin-bottom: 28px;
 
   font-size: 24px;
   font-weight: 700;
   line-height: 32px;
   color: var(--black-medium);
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .btn-section {
@@ -113,7 +119,9 @@
   }
 
   .title {
+    margin-right: 0;
     margin-top: 40px;
+    margin-bottom: 8px;
 
     font-size: 20px;
   }

--- a/src/components/dashboard/card/Card.module.css
+++ b/src/components/dashboard/card/Card.module.css
@@ -93,19 +93,6 @@
 
     margin-bottom: 0;
   }
-
-  .description-section {
-    display: flex;
-    align-items: center;
-  }
-
-  .card-tags {
-    margin-bottom: 0;
-  }
-
-  .card-date {
-    margin-left: 16px;
-  }
 }
 
 @media screen and (max-width: 743px) {

--- a/src/components/dashboard/card/CardImage.tsx
+++ b/src/components/dashboard/card/CardImage.tsx
@@ -21,6 +21,7 @@ function CardImage({ image, name, className }: ImageProps) {
         fill
         src={imgPath}
         alt={name || ''}
+        objectFit="cover"
         onError={() => setImageRenderError(true)}
       />
     </div>

--- a/src/components/dashboard/column/Column.module.css
+++ b/src/components/dashboard/column/Column.module.css
@@ -69,7 +69,7 @@
   content: '';
 
   position: absolute;
-  top: 50%;
+  top: 6px;
   left: 0;
 
   width: 8px;

--- a/src/components/dashboard/column/Column.module.css
+++ b/src/components/dashboard/column/Column.module.css
@@ -17,12 +17,22 @@
 
 .column-title {
   position: relative;
+  display: flex;
+
+  width: calc(100% - 30px);
 
   padding-left: 16px;
 
   font-size: 18px;
   font-weight: 700;
   line-height: 22px;
+}
+
+.column-title .title-text {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .btn-edit-column {

--- a/src/components/dashboard/column/Column.module.css
+++ b/src/components/dashboard/column/Column.module.css
@@ -11,7 +11,6 @@
 .column-title-section {
   display: flex;
   justify-content: space-between;
-  align-items: center;
 
   margin-bottom: 25px;
 }
@@ -27,6 +26,8 @@
 }
 
 .btn-edit-column {
+  flex-shrink: 0;
+
   width: 24px;
   height: 24px;
 

--- a/src/components/dashboard/column/Column.tsx
+++ b/src/components/dashboard/column/Column.tsx
@@ -100,7 +100,7 @@ function Column({
     <div className={styles.column}>
       <div className={styles['column-title-section']}>
         <div className={styles['column-title']}>
-          {columnTitle}
+          <span className={styles['title-text']}>{columnTitle}</span>
           <span className={styles['column-size']}>{columnData.totalCount}</span>
         </div>
         <button

--- a/src/components/product/dashboard/modify-card/ColumnTitleSection.module.css
+++ b/src/components/product/dashboard/modify-card/ColumnTitleSection.module.css
@@ -1,8 +1,10 @@
 .section {
+  max-width: calc(50% - 16px);
   width: 100%;
   margin-bottom: 32px;
 
   @media screen and (max-width: 743px) {
+    max-width: none;
     margin-bottom: 24px;
   }
 }
@@ -30,7 +32,7 @@
   height: 48px;
   border: 1px solid var(--gray-medium);
   border-radius: 8px;
-  padding: 11px 16px;
+  padding: 11px 46px 11px 16px;
   font-weight: 400;
   font-size: 16px;
   color: var(--black-medium);
@@ -85,5 +87,25 @@
 }
 
 .space {
+  flex-shrink: 0;
   width: 22px;
+}
+
+.status {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.status-content {
+  width: calc(100% - 30px);
+}
+
+.status-select {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.check-icon {
+  flex-shrink: 0;
 }

--- a/src/components/product/dashboard/modify-card/ColumnTitleSection.tsx
+++ b/src/components/product/dashboard/modify-card/ColumnTitleSection.tsx
@@ -26,7 +26,9 @@ export default function ColumnTitleSection({
       <div className={styles[`input-box`]}>
         {selectedColumnTitle ? (
           <div className={styles[`name-select`]}>
-            <Chip chipType="status">{selectedColumnTitle}</Chip>
+            <Chip chipType="status">
+              <span className={styles.status}>{selectedColumnTitle}</span>
+            </Chip>
           </div>
         ) : (
           <input
@@ -62,11 +64,19 @@ export default function ColumnTitleSection({
             >
               <div className={styles.calculate}>
                 {title === selectedColumnTitle ? (
-                  <Check width={22} height={22} />
+                  <Check
+                    className={styles['check-icon']}
+                    width={22}
+                    height={22}
+                  />
                 ) : (
                   <div className={styles.space} />
                 )}
-                <Chip chipType="status">{title}</Chip>
+                <div className={styles['status-content']}>
+                  <Chip chipType="status">
+                    <span className={styles['status-select']}>{title}</span>
+                  </Chip>
+                </div>
               </div>
             </div>
           ))}


### PR DESCRIPTION
### 이슈 번호

close #138 

### 변경 사항 요약
- 할 일 카드 모달 타이틀 영역 수정 (버튼 영역 침범 제한)
- 할 일 카드 tablet 반응형 날짜, 프로필 사진 pc, mobile과 통일
- 카드 이미지 뭉개짐 수정
- 컬럼 타이틀 dot 위치 수정
- 컬럼 타이틀 길어지면 ...(말 줄임)처리 + 관리(톱니바퀴) 버튼 영역 침범 제한
- 컬럼 이름이 길어지는 경우 Chip 공통 컴포넌트 사용하는 영역(할 일 카드, 할 일 수정 모달) UI 깨짐 수정

### 테스트 결과
#### 할 일 카드 모달 타이틀 영역 수정 (버튼 영역 침범 제한)
![image](https://github.com/user-attachments/assets/4a13333a-09f0-4a21-988e-78253b96119c)
#### 할 일 카드 tablet 반응형 날짜, 프로필 사진 pc, mobile과 통일
![image](https://github.com/user-attachments/assets/4ab74900-1b14-4b73-8e42-6aac1919f344)
#### 컬럼 타이틀 dot 위치 수정 & 컬럼 타이틀 길어지면 ...(말 줄임)처리 + 관리(톱니바퀴) 버튼 영역 침범 제한
![image](https://github.com/user-attachments/assets/ca7fef61-ce4d-4b3a-a350-371dd5968125)
#### Chip 공통 컴포넌트 사용하는 영역(할 일 카드, 할 일 수정 모달) UI 깨짐 수정
![image](https://github.com/user-attachments/assets/8101e28f-5044-4142-ab52-7fb11be20968)
![image](https://github.com/user-attachments/assets/3976cef9-b138-4975-a56c-e16b4f8fddd2)
