### PR TITLE
#155 마이페이지 이슈 수정

### DIFF
--- a/public/ic/ic_imageDelete.svg
+++ b/public/ic/ic_imageDelete.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="12" cy="12" r="10" fill="#9CA3AF"/>
+<path d="M8.08008 8L16.0801 16" stroke="white" stroke-width="1.8" stroke-linecap="round"/>
+<path d="M16 8L8 16" stroke="white" stroke-width="1.8" stroke-linecap="round"/>
+</svg>

--- a/src/components/common/sidebar/Sidebar.module.css
+++ b/src/components/common/sidebar/Sidebar.module.css
@@ -5,6 +5,7 @@
   padding: 20px 12px 0 8px;
   position: fixed;
   border-right: 1px solid var(--gray-medium);
+  z-index: 1;
 }
 
 .menu {
@@ -106,6 +107,7 @@
   height: 344px;
   padding: 32px;
   border-radius: 10px;
+  z-index: 11;
 }
 
 .modal h2 {

--- a/src/components/common/sidebar/Sidebar.tsx
+++ b/src/components/common/sidebar/Sidebar.tsx
@@ -81,6 +81,18 @@ export default function Sidebar() {
     setDashboards(sidebarDashboards);
   }, [sidebarDashboards]);
 
+  useEffect(() => {
+    // 모달 dim 부분 스크롤 막기
+    if (showModal) {
+      document.body.style.overflow = 'hidden'; // 스크롤 비활성화
+    } else {
+      document.body.style.overflow = ''; // 기본 스크롤 상태로 복구
+    }
+    return () => {
+      document.body.style.overflow = ''; // 컴포넌트가 unmount 될 때도 스크롤 상태 복구
+    };
+  }, [showModal]);
+
   return (
     <div className={styles.sidebar}>
       <Link href="/" className={styles.logo}>

--- a/src/components/product/mypage/ChangePassword.module.css
+++ b/src/components/product/mypage/ChangePassword.module.css
@@ -36,11 +36,35 @@
   }
 }
 
+.input-wrap {
+  display: flex;
+  align-items: center;
+  position: relative;
+  margin-bottom: 16px;
+}
+
+.error-wrap {
+  display: flex;
+  align-items: center;
+  position: relative;
+  margin-bottom: 8px;
+}
+
+.visible-button {
+  width: 24px;
+  height: 24px;
+  border: none;
+  position: absolute;
+  right: 16px;
+  background-color: var(--white);
+  cursor: pointer;
+}
+
 .input {
   width: 100%;
   height: 50px;
   padding: 15px 16px;
-  margin-bottom: 16px;
+
   border-radius: 8px;
   border: 1px solid var(--gray-medium);
   font-weight: 400;
@@ -59,19 +83,15 @@
 }
 
 .bottom-input {
-  margin-bottom: 24px;
+  margin-bottom: 8px;
 }
 
 .error-input {
   border: 1px solid red;
 }
 
-.error-margin {
-  margin-bottom: 2px;
-}
-
 .error-message {
   color: red;
   font-size: 14px;
-  margin-bottom: 16px;
+  margin-bottom: 24px;
 }

--- a/src/components/product/mypage/ChangePassword.tsx
+++ b/src/components/product/mypage/ChangePassword.tsx
@@ -3,6 +3,8 @@ import clsx from 'clsx';
 import changePassword from '@/lib/mypage/changePassword';
 import CDSButton from '@/components/common/button/CDSButton';
 import AuthModal from '@/components/common/modal/auth/AuthModal';
+import Visibility from 'public/ic/ic_visibility.svg';
+import InVisibility from 'public/ic/ic_invisibility.svg';
 import styles from './ChangePassword.module.css';
 
 interface CheangePasswordValue {
@@ -29,6 +31,18 @@ export default function ChangePassword({
   const [values, setValues] = useState(initialValue);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [modal, setModal] = useState(false);
+  const [passwordVisibility, setPasswordVisibility] = useState({
+    current: false,
+    new: false,
+    confirm: false,
+  });
+
+  const handleClick = (field: 'current' | 'new' | 'confirm') => {
+    setPasswordVisibility((prevVisibility) => ({
+      ...prevVisibility,
+      [field]: !prevVisibility[field],
+    }));
+  };
 
   const handleCancelClick = () => {
     setModal(false);
@@ -79,40 +93,71 @@ export default function ChangePassword({
       <p className={styles.title}>비밀번호 변경</p>
       <div>
         <p className={styles[`sub-title`]}>현재 비밀번호</p>
-        <input
-          value={values.password}
-          onChange={(e) => setValues({ ...values, password: e.target.value })}
-          className={styles.input}
-          placeholder="비밀번호 입력"
-        />
+        <div className={styles[`input-wrap`]}>
+          <input
+            value={values.password}
+            onChange={(e) => setValues({ ...values, password: e.target.value })}
+            className={styles.input}
+            placeholder="비밀번호 입력"
+            type={passwordVisibility.current ? 'text' : 'password'}
+          />
+          <button
+            className={styles[`visible-button`]}
+            type="button"
+            onClick={() => handleClick('current')}
+          >
+            {passwordVisibility.current ? <Visibility /> : <InVisibility />}
+          </button>
+        </div>
       </div>
       <div>
         <p className={styles[`sub-title`]}>새 비밀번호</p>
-        <input
-          value={values.newPassword}
-          onChange={(e) =>
-            setValues({ ...values, newPassword: e.target.value })
-          }
-          className={styles.input}
-          placeholder="새 비밀번호 입력"
-          onBlur={handleBlur}
-        />
+        <div className={styles[`input-wrap`]}>
+          <input
+            value={values.newPassword}
+            onChange={(e) =>
+              setValues({ ...values, newPassword: e.target.value })
+            }
+            className={styles.input}
+            placeholder="새 비밀번호 입력"
+            onBlur={handleBlur}
+            type={passwordVisibility.new ? 'text' : 'password'}
+          />
+          <button
+            className={styles[`visible-button`]}
+            type="button"
+            onClick={() => handleClick('new')}
+          >
+            {passwordVisibility.new ? <Visibility /> : <InVisibility />}
+          </button>
+        </div>
       </div>
       <div>
         <p className={styles[`sub-title`]}>새 비밀번호 확인</p>
-        <input
-          value={values.confirmPassword}
-          onChange={(e) =>
-            setValues({ ...values, confirmPassword: e.target.value })
-          }
-          className={clsx(
-            styles.input,
-            values.error ? styles['error-input'] : styles[`bottom-input`],
-            values.error ? styles['error-margin'] : '',
-          )}
-          placeholder="새 비밀번호 입력"
-          onBlur={handleBlur}
-        />
+        <div
+          className={values.error ? styles[`error-wrap`] : styles[`input-wrap`]}
+        >
+          <input
+            value={values.confirmPassword}
+            onChange={(e) =>
+              setValues({ ...values, confirmPassword: e.target.value })
+            }
+            className={clsx(
+              styles.input,
+              values.error ? styles['error-input'] : styles[`bottom-input`],
+            )}
+            placeholder="새 비밀번호 입력"
+            onBlur={handleBlur}
+            type={passwordVisibility.confirm ? 'text' : 'password'}
+          />
+          <button
+            className={styles[`visible-button`]}
+            type="button"
+            onClick={() => handleClick('confirm')}
+          >
+            {passwordVisibility.confirm ? <Visibility /> : <InVisibility />}
+          </button>
+        </div>
         {values.error && (
           <p className={styles['error-message']}>{values.error}</p>
         )}

--- a/src/components/product/mypage/ChangePassword.tsx
+++ b/src/components/product/mypage/ChangePassword.tsx
@@ -36,6 +36,7 @@ export default function ChangePassword({
     new: false,
     confirm: false,
   });
+  const [isLoading, setIsLoading] = useState(false);
 
   const handleClick = (field: 'current' | 'new' | 'confirm') => {
     setPasswordVisibility((prevVisibility) => ({
@@ -49,24 +50,23 @@ export default function ChangePassword({
   };
 
   const handleChangePassword = async () => {
+    setIsLoading(true);
     try {
       const { password, newPassword } = values;
+      console.log(values);
       const putData = { password, newPassword };
       await changePassword(putData);
 
-      setValues({
-        password: '',
-        newPassword: '',
-        confirmPassword: '',
-        error: null,
-      });
+      setValues(initialValue);
       setModal(true);
     } catch (e) {
       setModal(true);
       setErrorMessage(e.message);
+    } finally {
+      setIsLoading(false);
     }
   };
-
+  console.log(values);
   const handleBlur = () => {
     const { newPassword, confirmPassword } = values;
     if (newPassword !== confirmPassword) {
@@ -166,7 +166,7 @@ export default function ChangePassword({
         <CDSButton
           onClick={handleChangePassword}
           btnType="profile_save"
-          disabled={!isFormValid}
+          disabled={!isFormValid || isLoading}
         >
           변경
         </CDSButton>

--- a/src/components/product/mypage/ChangePassword.tsx
+++ b/src/components/product/mypage/ChangePassword.tsx
@@ -53,7 +53,6 @@ export default function ChangePassword({
     setIsLoading(true);
     try {
       const { password, newPassword } = values;
-      console.log(values);
       const putData = { password, newPassword };
       await changePassword(putData);
 
@@ -66,7 +65,6 @@ export default function ChangePassword({
       setIsLoading(false);
     }
   };
-  console.log(values);
   const handleBlur = () => {
     const { newPassword, confirmPassword } = values;
     if (newPassword !== confirmPassword) {

--- a/src/components/product/mypage/ModifyProfile.tsx
+++ b/src/components/product/mypage/ModifyProfile.tsx
@@ -95,7 +95,10 @@ export default function ModifyProfile() {
       const fileExtension = file.name.split('.').pop()?.toLowerCase();
       if (!fileExtension || !allowedExtensions.includes(fileExtension)) {
         toast.warning(
-          '허용되지 않는 파일 형식입니다 (png, gif, jpg만 등록 가능)',
+          <div>
+            허용되지 않는 파일 형식입니다
+            <br /> (png, gif, jpg만 등록 가능)
+          </div>,
         );
 
         return;

--- a/src/components/product/mypage/ModifyProfile.tsx
+++ b/src/components/product/mypage/ModifyProfile.tsx
@@ -38,6 +38,10 @@ export default function ModifyProfile() {
     }
   }, [user]);
 
+  const handleImageDelete = () => {
+    setPreview(null);
+  };
+
   const handleCancelClick = () => {
     setModal(false);
   };
@@ -56,6 +60,8 @@ export default function ModifyProfile() {
       let imageUrl = values.profileImageUrl;
       if (image) {
         imageUrl = await uploadImage(image);
+      } else if (!preview) {
+        imageUrl = null;
       }
       const putData = {
         nickname: values.nickname,
@@ -88,6 +94,9 @@ export default function ModifyProfile() {
       setImage(file);
       const imgURL = URL.createObjectURL(file);
       setPreview(imgURL);
+    } else {
+      setImage(null);
+      setPreview(null);
     }
   };
 
@@ -98,6 +107,7 @@ export default function ModifyProfile() {
         <ProfileImageInput
           preview={preview}
           onImageChange={handleImageChange}
+          onImageDelete={handleImageDelete}
         />
         <div>
           <ProfileInfoForm

--- a/src/components/product/mypage/ModifyProfile.tsx
+++ b/src/components/product/mypage/ModifyProfile.tsx
@@ -9,6 +9,7 @@ import ProfileImageInput from './ProfileImageInput';
 import ProfileInfoForm from './ProfileInfoForm';
 import ProfileModifyModal from './ProfileModifyModal';
 import styles from './ModifyProfile.module.css';
+import { toast } from 'react-toastify';
 
 interface ModifyValue {
   nickname: string;
@@ -77,7 +78,7 @@ export default function ModifyProfile() {
       );
       setModal(true);
     } catch (error) {
-      console.error(error);
+      toast.error(error.message);
     }
   };
 

--- a/src/components/product/mypage/ModifyProfile.tsx
+++ b/src/components/product/mypage/ModifyProfile.tsx
@@ -91,6 +91,16 @@ export default function ModifyProfile() {
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) {
+      const allowedExtensions = ['png', 'gif', 'jpg', 'jpeg'];
+      const fileExtension = file.name.split('.').pop()?.toLowerCase();
+      if (!fileExtension || !allowedExtensions.includes(fileExtension)) {
+        toast.warning(
+          '허용되지 않는 파일 형식입니다 (png, gif, jpg만 등록 가능)',
+        );
+
+        return;
+      }
+
       setImage(file);
       const imgURL = URL.createObjectURL(file);
       setPreview(imgURL);

--- a/src/components/product/mypage/ProfileImageInput.module.css
+++ b/src/components/product/mypage/ProfileImageInput.module.css
@@ -22,6 +22,13 @@
   object-fit: cover;
 }
 
+.img-delete {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  cursor: pointer;
+}
+
 .img-input {
   display: none;
 }

--- a/src/components/product/mypage/ProfileImageInput.tsx
+++ b/src/components/product/mypage/ProfileImageInput.tsx
@@ -63,6 +63,7 @@ export default function ProfileImageInput({
         onChange={onImageChange}
         className={styles[`img-input`]}
         ref={imageInputRef}
+        accept=".gif, .jpg, .png"
       />
     </div>
   );

--- a/src/components/product/mypage/ProfileImageInput.tsx
+++ b/src/components/product/mypage/ProfileImageInput.tsx
@@ -1,21 +1,43 @@
-// ProfileImageInput.tsx
-import React from 'react';
+import React, { useRef } from 'react';
 import Image from 'next/image';
 import Plus from 'public/ic/ic_imgplus.svg';
+import ImageDelete from 'public/ic/ic_imageDelete.svg';
 import styles from './ProfileImageInput.module.css';
 
 interface ProfileImageInputProps {
   preview: string | null;
   onImageChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onImageDelete: () => void;
 }
 
 export default function ProfileImageInput({
   preview,
   onImageChange,
+  onImageDelete,
 }: ProfileImageInputProps) {
+  const imageInputRef = useRef<HTMLInputElement | null>(null);
+
+  const handleDeleteClick = (e: React.MouseEvent<SVGSVGElement>) => {
+    e.stopPropagation();
+    e.preventDefault();
+    onImageDelete();
+
+    if (imageInputRef.current) {
+      imageInputRef.current.value = '';
+    }
+  };
+
   return (
     <div className={styles[`img-input-box`]}>
-      <label htmlFor="profile-image" className={styles[`label-input`]}>
+      <label
+        htmlFor="profile-image"
+        className={styles[`label-input`]}
+        onClick={(e) => {
+          if (preview) {
+            e.preventDefault();
+          }
+        }}
+      >
         {preview ? (
           <div className={styles[`preview-container`]}>
             <Image
@@ -23,6 +45,12 @@ export default function ProfileImageInput({
               alt="프로필 미리보기 이미지"
               fill
               className={styles[`img-preview`]}
+            />
+            <ImageDelete
+              className={styles[`img-delete`]}
+              width={18}
+              height={18}
+              onClick={handleDeleteClick}
             />
           </div>
         ) : (
@@ -34,6 +62,7 @@ export default function ProfileImageInput({
         id="profile-image"
         onChange={onImageChange}
         className={styles[`img-input`]}
+        ref={imageInputRef}
       />
     </div>
   );

--- a/src/lib/mypage/modifyProfile.ts
+++ b/src/lib/mypage/modifyProfile.ts
@@ -20,11 +20,12 @@ export default async function modifyProfile(
   try {
     const res = await instance.put(`/11-6/users/me`, data);
     return res.data;
-  } catch (error: unknown) {
-    if (error instanceof Error) {
-      throw new Error(`프로필 수정에 실패했어요: ${error.message}`);
-    } else {
-      throw new Error('프로필 수정에 실패했어요: 알 수 없는 오류');
+  } catch (error) {
+    if (error.response) {
+      console.error('API 응답 에러:', error.response.data);
     }
+    throw new Error(
+      error.response?.data?.message || '프로필을 수정하는데 실패했어요',
+    );
   }
 }

--- a/src/pages/mypage/index.module.css
+++ b/src/pages/mypage/index.module.css
@@ -11,7 +11,7 @@
 }
 
 .box {
-  margin-left: 280px;
+  margin-left: 300px;
 
   @media screen and (max-width: 1199px) {
     margin-left: 160px;


### PR DESCRIPTION
### 이슈 번호

close #155 

### 변경 사항 요약

- 프로필 + 버튼 위치 수정 필요합니다. (디자인) ☑️
- 프로필 이미지 radius가 이상합니다. (디자인)  ☑️
- 닉네임 수정시 에러나면 에러 표시가 필요해보입니다 (추가) ☑️
   -> 서버의 에러 리스폰스 출력했습니다.
- 비밀번호 변경도 비밀번호 표시 껐다 키는 버튼이 있어도 좋을 것 같습니다 (추가) ☑️
- 새 비밀번호 / 확인 검사 로직에 버그가 있습니다. (버그) ⇒ 다시 되서 확인 한번만 해보시면 좋을 것 같습니다. ☑️
- 현재 비밀번호를 똑같이 쳐도 틀렸다고 나옵니다. 기존의 비밀번호 12345678임 (버그) ⇒ 다시 되서 확인 한번만 해보시면 좋을 것 같습니다. ☑️
   -> 해당 버그들은 서버에서 에러 리스폰스 보내주는 내용을 출력하는 부분에서 발생하는 친구들입니다. 테스트간 작동했다 안했다 했기에 로딩 상태에 따른 동작을 추가했습니다.
- 대시보드 추가 누르면 z-index 안맞음, 이때 뒤에 스크롤도 됨 (버그) ☑️
   -> 확인해보니 마이페이지 뿐 아니라 모든 페이지에서 대시보드 생성 모달이 동일한 문제를 일으켰습니다.
   -> sidebar의 fixed 속성때문인듯 하였고, 관련 모달 내부 요소, 사이드바의 z-index를 조절해서 수정했습니다.
- 프로필 이미지 추가/변경 validation 적용 필요 ☑️
  -> 서버에서 에러로 보내주는 내용 외 확장자 관련 검증 로직 추가했습니다.
### 테스트 결과
<프로필, 버튼 css 조정>
![스크린샷 2024-12-26 233322](https://github.com/user-attachments/assets/8b0540a1-c5d0-4c43-8f57-14d2106a6937)
<프로필 이미지 삭제 기능 추가>
![스크린샷 2024-12-26 233337](https://github.com/user-attachments/assets/fe1e0b0f-5c33-48d1-823f-81f691f8980b)
<닉네임 수정시 에러 출력>
![스크린샷 2024-12-26 233358](https://github.com/user-attachments/assets/01ef371c-1119-4d1f-8122-5208894dada8)
<비밀번호 가시화 토글>
![스크린샷 2024-12-26 233422](https://github.com/user-attachments/assets/bee600ce-e529-4cf7-a6e6-57f58dff7c5c)
<페이지별 모달 순서 확인>
![스크린샷 2024-12-26 233124](https://github.com/user-attachments/assets/ca3464d0-8cbe-4372-be75-303cbcca5b1e)
![스크린샷 2024-12-26 233148](https://github.com/user-attachments/assets/1b30d496-9375-441a-89e5-58780b29504b)
<프로필 이미지 확장자 검증>
![스크린샷 2024-12-26 233541](https://github.com/user-attachments/assets/5548baca-6ddf-4df3-a812-94a59a3a65bf)