### PR TITLE
페이지 대시보드 수정 - 초대내역, 구성원 style 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5473,9 +5473,7 @@
       "version": "11.15.0",
       "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.15.0.tgz",
       "integrity": "sha512-MLk8IvZntxOMg7lDBLw2qgTHHv664bYoYmnFTmE0Gm/FW67aOJk0WM3ctMcG+Xhcv+vh5uyyXwxvxhSeJzSe+w==",
-
       "license": "MIT",
-
       "dependencies": {
         "motion-dom": "^11.14.3",
         "motion-utils": "^11.14.3",
@@ -6484,18 +6482,14 @@
     "node_modules/motion-dom": {
       "version": "11.14.3",
       "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.14.3.tgz",
-
       "integrity": "sha512-lW+D2wBy5vxLJi6aCP0xyxTxlTfiu+b+zcpVbGVFUxotwThqhdpPRSmX8xztAgtZMPMeU0WGVn/k1w4I+TbPqA==",
       "license": "MIT"
-
     },
     "node_modules/motion-utils": {
       "version": "11.14.3",
       "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.14.3.tgz",
-
       "integrity": "sha512-Xg+8xnqIJTpr0L/cidfTTBFkvRw26ZtGGuIhA94J9PQ2p4mEa06Xx7QVYZH0BP+EpMSaDlu+q0I0mmvwADPsaQ==",
       "license": "MIT"
-
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/src/components/product/edit/InviteTitle/InviteList.module.css
+++ b/src/components/product/edit/InviteTitle/InviteList.module.css
@@ -3,36 +3,34 @@
 	justify-content: space-between;
 	padding-right: 28px;
 	padding-left: 28px;
-	margin-top: 10px;
+  margin-bottom: 16px;
 }
 
 .title {
-  margin-top: 6px;
   font-size: 18px;
   font-weight: 400;
   line-height: 26px;
 }
 
 .line {
-	margin-top: 10px;
+  margin-bottom: 16px;
   border: none;
   border-top: 1px solid var(--gray-bright); 
 }
 
 @media screen and (max-width: 743px) {
   .container {
-    padding-left: 0;
-    padding-right: 0;
-    margin-top: 10px;
+    padding-left: 20px;
+    padding-right: 20px;
+    margin-bottom: 10px;
   }
   
   .title {
-    margin-top: 5px;
+    font-size: 14px;
+    line-height: 24px;
   }
 
   .line {
-    margin-top: 5px;
-    font-size: 14px;
-    line-height: 24px;
+    margin-bottom: 10px;
   }
 }

--- a/src/components/product/edit/InviteTitle/InviteTitle.module.css
+++ b/src/components/product/edit/InviteTitle/InviteTitle.module.css
@@ -12,6 +12,8 @@
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
+  align-items: center;
+  margin-bottom: 32px;
 }
 
 .title {
@@ -20,7 +22,6 @@
 	line-height: 32px;
 	padding-right: 28px;
   padding-left: 28px;
-  margin-bottom: 20px;
 }
 
 .button-section {
@@ -103,10 +104,12 @@
 
 	.title {
 		font-size: 20px;
+    padding-right: 15px;
+    padding-left: 15px;
+    margin-top: -30px;
 	}
 
   .button-section { 
-    margin-top: 5px;
     flex-direction: column;
     gap: 0;
   }
@@ -124,7 +127,7 @@
   }
 
 	.sub-title {
-		margin-top: -30px;
+		margin-top: -55px;
 		font-weight: 400;
 		font-size: 14px;
 		line-height: 24px;
@@ -132,5 +135,9 @@
 
   .invite-button-section {
     margin: 8px 0 0 auto;
+  }
+
+  .list {
+    margin-top: 45px;
   }
 }

--- a/src/components/product/edit/InviteTitle/InviteTitle.module.css
+++ b/src/components/product/edit/InviteTitle/InviteTitle.module.css
@@ -18,7 +18,8 @@
 	font-weight: 700;
 	font-size: 24px;
 	line-height: 32px;
-	padding-left: 14px;
+	padding-right: 28px;
+  padding-left: 28px;
   margin-bottom: 20px;
 }
 
@@ -65,8 +66,8 @@
 }
 
 .sub-title {
-	margin-top: 20px;
-  margin-left: 15px;
+	margin-top: 32px;
+  margin-left: 28px;
   margin-bottom: 20px;
 	font-weight: 400;
 	font-size: 16px;

--- a/src/components/product/edit/InviteTitle/InviteTitle.module.css
+++ b/src/components/product/edit/InviteTitle/InviteTitle.module.css
@@ -81,10 +81,6 @@
 		width: 544px;
 	}
 
-  .pagination-button {
-    display: none;
-  }
-
 	.sub-title {
 		margin-top: 15px;
 	}

--- a/src/components/product/edit/InviteTitle/InviteTitle.tsx
+++ b/src/components/product/edit/InviteTitle/InviteTitle.tsx
@@ -100,7 +100,9 @@ export default function InviteTitle() {
       </div>
       <div className={styles['name-section']}>
         <h2 className={styles['sub-title']}>이메일</h2>
-        <InviteList members={members} />
+        <div className={styles['list']}>
+          <InviteList members={members} />
+        </div>
       </div>
       <div>
         <InviteModal

--- a/src/components/product/edit/MemberTitle/MemberList.module.css
+++ b/src/components/product/edit/MemberTitle/MemberList.module.css
@@ -3,7 +3,7 @@
 	justify-content: space-between;
 	padding-right: 28px;
 	padding-left: 28px;
-	margin-top: 10px;
+	margin-bottom: 16px;
 }
 
 .crown {
@@ -13,14 +13,14 @@
 }
 
 .line {
-	margin-top: 10px;
+	margin-bottom: 16px;
   border: none;
   border-top: 1px solid var(--gray-bright); 
 }
 
 @media screen and (max-width: 743px) {
   .container {
-    margin-top: 8px;
+    margin-bottom: 12px;
   }
 
   .crown {
@@ -31,6 +31,6 @@
   }
 
   .line {
-    margin-top: 13px;
+    margin-bottom: 12px;
   }
 }

--- a/src/components/product/edit/MemberTitle/MemberTitle.module.css
+++ b/src/components/product/edit/MemberTitle/MemberTitle.module.css
@@ -12,6 +12,8 @@
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
+  align-items: center;
+  margin-bottom: 27px;
 }
 
 .title {
@@ -19,7 +21,6 @@
 	font-size: 24px;
 	line-height: 32px;
 	padding-left: 14px;
-  margin-bottom: 20px;
 }
 
 .button {
@@ -39,7 +40,7 @@
 .sub-title {
 	margin-top: 20px;
   margin-left: 15px;
-	margin-bottom: 20px;
+	margin-bottom: 19px;
 	font-weight: 400;
 	font-size: 16px;
 	line-height: 26px;
@@ -64,6 +65,9 @@
 		padding: 20px 16px 20px 16px;
 	}
 
+  .member-section  {
+    margin-bottom: 18px;
+  }
   .page-info {
     margin-right: 10px;
     font-weight: 400;


### PR DESCRIPTION
### 이슈 번호

close #'59'

### 변경 사항 요약

- 피그마에 맞게 스타일 수정했습니다.

### 테스트 결과

- 데스크탑
<img width="497" alt="스크린샷 2024-12-27 오전 1 51 31" src="https://github.com/user-attachments/assets/36518992-a1ec-482b-8682-2e69338db4d4" />

-  태블릿 화면
<img width="444" alt="스크린샷 2024-12-27 오전 11 00 41" src="https://github.com/user-attachments/assets/6a2f3a85-c764-4b3e-a362-0f2180aa8e4b" />

- 모바일 화면
<img width="231" alt="스크린샷 2024-12-27 오전 1 52 45" src="https://github.com/user-attachments/assets/3b09398b-9e94-42a8-8482-7c1461edce72" />

### 리뷰포인트

- 모바일 버전에서 초대내역 부분은 초대내역 버튼의 구역을 맞추느라 임의로 수정한 부분이 있습니다.  이 부분은 최대한 피그마에 맞게 디자인했는데, 괜찮은지 확인 부탁드립니다!