### PR TITLE
#166 할 일 수정 모달 이슈 수정

### DIFF
--- a/src/components/common/input/info-input/DeadlineInput.tsx
+++ b/src/components/common/input/info-input/DeadlineInput.tsx
@@ -26,7 +26,8 @@ const StyledTextField = styled(TextField)(({ theme }) => ({
       borderColor: '#d9d9d9',
     },
     '&.Mui-focused fieldset': {
-      borderColor: 'black',
+      borderColor: 'var(--violet)',
+      borderWidth: '1px',
     },
   },
   '& .MuiInputBase-root': {

--- a/src/components/dashboard/card/Card.tsx
+++ b/src/components/dashboard/card/Card.tsx
@@ -95,7 +95,7 @@ function Card({
         </OverlayContainer>
       )}
       {isModifyModalOpen && (
-        <OverlayContainer>
+        <OverlayContainer onClose={handleCloseModifyModal}>
           <ModifyCard
             closeModal={handleCloseModifyModal}
             columnTitle={columnTitle}

--- a/src/components/product/dashboard/create-card/CreateCard.module.css
+++ b/src/components/product/dashboard/create-card/CreateCard.module.css
@@ -3,22 +3,22 @@
   height: 80%;
   max-height: 966px;
   border-radius: 16px;
-  padding: 9px 6px;
+  padding: 6px 6px 9px 6px;
   background-color: var(--white);
+
   @media screen and (max-width: 743px) {
     width: 380px;
     height: 70%;
     max-height: 766px;
-    padding: 9px 6px;
   }
 }
 
 .scrollable-content {
   height: 100%;
   overflow-y: auto;
-  padding: 22px 26px;
+  padding: 0px 26px 22px 26px;
   @media screen and (max-width: 743px) {
-    padding: 18px 14px;
+    padding: 0px 14px 18px 14px;
   }
 }
 
@@ -29,6 +29,32 @@
   @media screen and (max-width: 743px) {
     margin-bottom: 24px;
   }
+}
+
+.header-container {
+  position: sticky;
+  top: 0;
+  z-index: 11;
+  background-color: var(--white);
+  margin-top: 22px;
+}
+
+.header-section {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.btn-close {
+  border: 0;
+  background-color: transparent;
+
+  cursor: pointer;
+}
+
+.icon-close {
+  width: 32px;
+  height: 32px;
 }
 
 .title {

--- a/src/components/product/dashboard/create-card/CreateCard.tsx
+++ b/src/components/product/dashboard/create-card/CreateCard.tsx
@@ -14,6 +14,8 @@ import ButtonSection from './ButtonSection';
 import AssigneeSection from './AssigneeSection';
 import DescriptionInput from './DescriptionInput';
 import { toast } from 'react-toastify';
+import clsx from 'clsx';
+import CloseIcon from 'public/ic/ic_x.svg';
 import styles from './CreateCard.module.css';
 
 interface CreateCardProps {
@@ -128,8 +130,17 @@ export default function CreateCard({
     <OverlayContainer onClose={onClose}>
       <div className={styles.container} onClick={(e) => e.stopPropagation()}>
         <div className={`${styles[`scrollable-content`]} custom-scroll`}>
-          <section className={styles.section}>
-            <p className={styles.title}>할 일 생성</p>
+          <section className={clsx(styles.section, styles[`header-container`])}>
+            <div className={styles['header-section']}>
+              <p className={styles.title}>할 일 생성</p>
+              <button
+                type="button"
+                className={styles['btn-close']}
+                onClick={onClose}
+              >
+                <CloseIcon className={styles['icon-close']} />
+              </button>
+            </div>
           </section>
           <AssigneeSection
             members={members}

--- a/src/components/product/dashboard/modify-card/ColumnTitleSection.module.css
+++ b/src/components/product/dashboard/modify-card/ColumnTitleSection.module.css
@@ -92,8 +92,14 @@
 }
 
 .status {
+  font-size: 14px;
+  font-weight: 400;
   overflow: hidden;
   text-overflow: ellipsis;
+
+  @media screen and (max-width: 743px) {
+    font-size: 12px;
+  }
 }
 
 .status-content {

--- a/src/components/product/dashboard/modify-card/ColumnTitleSection.module.css
+++ b/src/components/product/dashboard/modify-card/ColumnTitleSection.module.css
@@ -25,6 +25,7 @@
 
 .input-box {
   position: relative;
+  cursor: pointer;
 }
 
 .name-select {
@@ -110,6 +111,12 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  font-size: 14px;
+  font-weight: 400;
+
+  @media screen and (max-width: 743px) {
+    font-size: 12px;
+  }
 }
 
 .check-icon {

--- a/src/components/product/dashboard/modify-card/ColumnTitleSection.tsx
+++ b/src/components/product/dashboard/modify-card/ColumnTitleSection.tsx
@@ -23,7 +23,7 @@ export default function ColumnTitleSection({
   return (
     <section className={styles.section}>
       <p className={styles.topic}>상태</p>
-      <div className={styles[`input-box`]}>
+      <div className={styles[`input-box`]} onClick={onToggleDropdown}>
         {selectedColumnTitle ? (
           <div className={styles[`name-select`]}>
             <Chip chipType="status">
@@ -43,7 +43,6 @@ export default function ColumnTitleSection({
           className={styles[`toggle-button`]}
           width={26}
           height={26}
-          onClick={onToggleDropdown}
         />
       </div>
       {isDropdownOpen && (

--- a/src/components/product/dashboard/modify-card/ModifyCard.module.css
+++ b/src/components/product/dashboard/modify-card/ModifyCard.module.css
@@ -3,22 +3,23 @@
   height: 80%;
   max-height: 966px;
   border-radius: 16px;
-  padding: 9px 6px;
+  padding: 6px 6px 9px 6px;
+
   background-color: var(--white);
   @media screen and (max-width: 743px) {
     width: 380px;
     height: 70%;
     max-height: 766px;
-    padding: 9px 6px;
   }
 }
 
 .scrollable-content {
   height: 100%;
   overflow-y: auto;
-  padding: 22px 26px;
+
+  padding: 0px 26px 22px 26px;
   @media screen and (max-width: 743px) {
-    padding: 18px 14px;
+    padding: 0px 14px 18px 14px;
   }
 }
 
@@ -29,6 +30,32 @@
   @media screen and (max-width: 743px) {
     margin-bottom: 24px;
   }
+}
+
+.header-container {
+  position: sticky;
+  top: 0;
+  z-index: 11;
+  background-color: var(--white);
+  margin-top: 22px;
+}
+
+.header-section {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.btn-close {
+  border: 0;
+  background-color: transparent;
+
+  cursor: pointer;
+}
+
+.icon-close {
+  width: 32px;
+  height: 32px;
 }
 
 .first-section {

--- a/src/components/product/dashboard/modify-card/ModifyCard.tsx
+++ b/src/components/product/dashboard/modify-card/ModifyCard.tsx
@@ -65,6 +65,7 @@ export default function ModifyCard({
     columnTitle,
     assigneeNickname: cardInfo?.assignee?.nickname || '',
   });
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const { image, preview, handleImageChange } = useCardImageUploader(
     cardInfo?.imageUrl || null,
@@ -172,6 +173,8 @@ export default function ModifyCard({
       dispatch,
       initialData,
       setInitialData,
+      isSubmitting,
+      setIsSubmitting,
     });
   };
 
@@ -233,7 +236,7 @@ export default function ModifyCard({
         <ModifyButtonSection
           onCancel={closeModal}
           onSubmit={handleSubmit}
-          isDisabled={isDisabled}
+          isDisabled={isDisabled || isSubmitting}
         />
       </div>
     </div>

--- a/src/components/product/dashboard/modify-card/ModifyCard.tsx
+++ b/src/components/product/dashboard/modify-card/ModifyCard.tsx
@@ -13,6 +13,7 @@ import getColumns from '@/lib/dashboard/getColumns';
 import useColumnData from '@/hooks/useColumnData';
 import useButtonState from '@/hooks/useModifyButtonState';
 import { GetColumnsResponse } from '@/type/column';
+import CloseIcon from 'public/ic/ic_x.svg';
 import TagManager from '../create-card/TagManager';
 import DescriptionInput from '../create-card/DescriptionInput';
 import CardImageInput from '../create-card/CardImageInput';
@@ -181,8 +182,17 @@ export default function ModifyCard({
   return (
     <div className={styles.container} onClick={(e) => e.stopPropagation()}>
       <div className={`${styles[`scrollable-content`]} custom-scroll`}>
-        <section className={styles.section}>
-          <p className={styles.title}>할 일 수정</p>
+        <section className={clsx(styles.section, styles[`header-container`])}>
+          <div className={styles['header-section']}>
+            <p className={styles.title}>할 일 수정</p>
+            <button
+              type="button"
+              className={styles['btn-close']}
+              onClick={closeModal}
+            >
+              <CloseIcon className={styles['icon-close']} />
+            </button>
+          </div>
         </section>
         <section className={clsx(styles.section, styles[`first-section`])}>
           <ColumnTitleSection

--- a/src/components/product/dashboard/modify-card/ModifyCard.tsx
+++ b/src/components/product/dashboard/modify-card/ModifyCard.tsx
@@ -176,7 +176,7 @@ export default function ModifyCard({
   };
 
   return (
-    <div className={styles.container}>
+    <div className={styles.container} onClick={(e) => e.stopPropagation()}>
       <div className={`${styles[`scrollable-content`]} custom-scroll`}>
         <section className={styles.section}>
           <p className={styles.title}>할 일 수정</p>

--- a/src/lib/dashboard/putCardSubmit.ts
+++ b/src/lib/dashboard/putCardSubmit.ts
@@ -20,7 +20,15 @@ const putCardSubmit = async ({
   dispatch,
   initialData,
   setInitialData,
+  isSubmitting,
+  setIsSubmitting,
 }) => {
+  if (isSubmitting) {
+    toast.error('이미 요청을 보내고 있습니다.');
+    return;
+  }
+  setIsSubmitting(true);
+
   try {
     let imageUrl = cardInfo?.imageUrl || null;
     if (image) {
@@ -52,7 +60,9 @@ const putCardSubmit = async ({
     await onUpdate();
     await closeModal();
   } catch (error) {
-    console.error('handleSubmit Error:', error);
+    toast.error(error.message);
+  } finally {
+    setIsSubmitting(false);
   }
 };
 


### PR DESCRIPTION
### 이슈 번호

close #166 

### 변경 사항 요약
 - 컬럼 타이틀 칩 글자 크기 수정
 - 수정 모달 dim 부분 클릭시 모달 닫힘
 - 컬럼 타이틀 인풋 클릭시 드롭다운
 - 마감일 border 보라색으로 통일
 - 카드 수정 중 로딩 상태 반영 및 서버 에러 리스폰스 toast 출력
 - 카드 수정 및 생성 제목을 모달 상단에 고정, x 버튼 추가

### 테스트 결과
![스크린샷 2024-12-27 165455](https://github.com/user-attachments/assets/67340543-77ab-44d0-8a4f-c4d1e03fe5e7)

### 리뷰 포인트
- 이미지 업로드 버튼 hover 기능은 차차 반영하겠습니다.
- 전체 버튼에 hover 적용해도 좋을 것 같아요! 😄 