### PR TITLE
대시보드수정페이지 - 멤버 삭제시 reload()대신 dispatch사용

### DIFF
--- a/src/components/product/edit/MemberTitle/MemberList.tsx
+++ b/src/components/product/edit/MemberTitle/MemberList.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react';
 import UserProfile from '@/components/common/userprofile/UserProfile';
 import CDSButton from '@/components/common/button/CDSButton';
 import Crown from 'public/ic/ic_crown.svg';
-import { useRouter } from 'next/router';
 import deleteMembers from '@/lib/editdashboard/deleteMembers';
 import styles from './MemberList.module.css';
 
@@ -49,10 +48,10 @@ interface DashboardMember {
 
 interface MeberListProps {
   members: DashboardMember[] | undefined;
+  setMembers: React.Dispatch<React.SetStateAction<DashboardMember[]>>;
 }
 
-export default function MemberList({ members }: MeberListProps) {
-  const router = useRouter();
+export default function MemberList({ members, setMembers }: MeberListProps) {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedMemberId, setSelectedMemberId] = useState<number | null>(null);
 
@@ -71,7 +70,9 @@ export default function MemberList({ members }: MeberListProps) {
 
     try {
       await deleteMembers(selectedMemberId);
-      router.reload();
+      setMembers((prevMembers) =>
+        prevMembers.filter((member) => member.id !== selectedMemberId),
+      );
     } catch (error) {
       throw new Error(`${error}`);
     } finally {

--- a/src/components/product/edit/MemberTitle/MemberTitle.tsx
+++ b/src/components/product/edit/MemberTitle/MemberTitle.tsx
@@ -62,7 +62,7 @@ export default function MemberTitle() {
       </div>
       <div className={styles['name-section']}>
         <h2 className={styles['sub-title']}>이름</h2>
-        <MemberList members={members} />
+        <MemberList members={members} setMembers={setMembers} />
       </div>
     </section>
   );


### PR DESCRIPTION
### 이슈 번호

close #'59'

### 변경 사항 요약

- 멤버 삭제에 아직 reload()가 남아있어 dispatch로 변경했습니다.

### 테스트 결과

### 리뷰포인트