### PR TITLE
💄 대시보드 이름 길어지면 말줄임 처리

### DIFF
--- a/src/components/common/button/Button.module.css
+++ b/src/components/common/button/Button.module.css
@@ -176,6 +176,7 @@
 }
 
 .icon-crown {
+  flex-shrink: 0;
   display: block;
   width: 20px;
   height: 16px;
@@ -190,6 +191,7 @@
 }
 
 .badge {
+  flex-shrink: 0;
   width: 8px;
   height: 8px;
   margin-right: 16px;

--- a/src/components/product/mydashboard/DashboardList.module.css
+++ b/src/components/product/mydashboard/DashboardList.module.css
@@ -11,6 +11,13 @@
   gap: 13px;
 }
 
+.dashboard-title {
+  max-width: calc(100% - 40px);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .color-circle {
   width: 8px;
   height: 8px;

--- a/src/components/product/mydashboard/DashboardList.tsx
+++ b/src/components/product/mydashboard/DashboardList.tsx
@@ -114,7 +114,7 @@ export default function DashboardList() {
                 owner={item.createdByMe}
                 onClick={() => handleClick(item.id)}
               >
-                {item.title}
+                <span className={styles['dashboard-title']}>{item.title}</span>
               </CDSButton>
             </li>
           ))

--- a/src/components/product/mydashboard/InvitationList.module.css
+++ b/src/components/product/mydashboard/InvitationList.module.css
@@ -49,6 +49,7 @@
   width: 100%;
   border-collapse: collapse;
   padding-left: 60px;
+  margin-bottom: 70px;
 }
 
 .table-head th,
@@ -70,7 +71,7 @@
   color: var(--gray-dark);
 }
 
-.table-body td {
+.table-content-dashboard {
   font-size: 16px;
   font-weight: 400;
   color: var(--black-medium);
@@ -108,6 +109,10 @@
   font-size: 18px;
   font-weight: 400;
   color: var(--gray-dark);
+}
+
+.button-text {
+  font-size: 14px;
 }
 
 .skeleton {

--- a/src/components/product/mydashboard/InvitationList.tsx
+++ b/src/components/product/mydashboard/InvitationList.tsx
@@ -49,11 +49,15 @@ export default function InvitationList() {
       setIsLoading(true);
 
       try {
-        const response = await getInvitations({
+        // 공백 제거 후 title 처리
+        const trimmedKeyword = keyword?.trim();
+        const params = {
           size: 10,
           cursorId: reset ? null : cursorId,
-          title: keyword,
-        });
+          ...(trimmedKeyword ? { title: trimmedKeyword } : {}),
+        };
+
+        const response = await getInvitations(params);
 
         if (response.invitations.length > 0) {
           setInvitations((prev) =>
@@ -74,9 +78,11 @@ export default function InvitationList() {
   );
 
   const handleSearch = () => {
+    const trimmedKeyword = keyword?.trim();
     setHasMore(true);
     setCursorId(null);
     setInvitations([]);
+    setKeyword(trimmedKeyword || null);
     fetchInvitations(true);
   };
 
@@ -178,7 +184,7 @@ export default function InvitationList() {
                     <span className={styles['table-content-title']}>
                       초대자
                     </span>
-                    <span className={styles['table-content-dashbaord']}>
+                    <span className={styles['table-content-dashboard']}>
                       {invite.inviter.nickname}
                     </span>
                   </td>
@@ -191,13 +197,13 @@ export default function InvitationList() {
                           btnType="normal_colored"
                           onClick={() => handleInvitation('accept', invite.id)}
                         >
-                          <span>수락</span>
+                          <span className={styles['button-text']}>수락</span>
                         </CDSButton>
                         <CDSButton
                           btnType="normal"
                           onClick={() => handleInvitation('reject', invite.id)}
                         >
-                          <span>거절</span>
+                          <span className={styles['button-text']}>거절</span>
                         </CDSButton>
                       </>
                     )}

--- a/src/lib/mydashboard/getInvitations.ts
+++ b/src/lib/mydashboard/getInvitations.ts
@@ -19,7 +19,10 @@ export default async function getinvitations(
     const { data } = await instance.get<GetInvitationsResponse>(
       `/11-6/invitations/`,
       {
-        params,
+        params: {
+          ...params,
+          title: params.title?.trim() ? params.title : undefined,
+        },
       },
     );
     return data;


### PR DESCRIPTION
### 이슈 번호

close #184 

### 변경 사항 요약
- 대시보드 이름 길어지면 말줄임 처리
- 초대받은 대시보드 padding 및 폰트 수정
- 대시보드 하단 마진 추가
- 공백 입력 시 400에러 해결

### 테스트 결과
#### PC
![image](https://github.com/user-attachments/assets/8bfa14f6-6a23-422e-84fa-6e169df110f3)
![image](https://github.com/user-attachments/assets/d717d79a-f5c4-4e62-9ed4-0cea7d672f05)
![image](https://github.com/user-attachments/assets/b7d44cef-15da-4f83-91a6-bf256c3972e1)

#### Tablet
![image](https://github.com/user-attachments/assets/56e5e443-5d96-4eed-8136-b3e1715bfd40)
#### Mobile
![image](https://github.com/user-attachments/assets/95853c6d-a6b7-4245-9213-5df61eb3b1cc)
